### PR TITLE
fix: add missing Rooms interface

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/ChatClient.kt
+++ b/chat-android/src/main/java/com/ably/chat/ChatClient.kt
@@ -12,7 +12,7 @@ interface ChatClient {
     /**
      * The rooms object, which provides access to chat rooms.
      */
-    val room: Room
+    val rooms: Rooms
 
     /**
      * The underlying connection to Ably, which can be used to monitor the clients

--- a/chat-android/src/main/java/com/ably/chat/Rooms.kt
+++ b/chat-android/src/main/java/com/ably/chat/Rooms.kt
@@ -1,0 +1,37 @@
+package com.ably.chat
+
+/**
+ * Manages the lifecycle of chat rooms.
+ */
+interface Rooms {
+    /**
+     * Get the client options used to create the Chat instance.
+     */
+    val clientOptions: ClientOptions
+
+    /**
+     * Gets a room reference by ID. The Rooms class ensures that only one reference
+     * exists for each room. A new reference object is created if it doesn't already
+     * exist, or if the one used previously was released using release(roomId).
+     *
+     * Always call `release(roomId)` after the Room object is no longer needed.
+     *
+     * @param roomId The ID of the room.
+     * @param options The options for the room.
+     * @throws {@link ErrorInfo} if a room with the same ID but different options already exists.
+     * @returns Room A new or existing Room object.
+     */
+    fun get(roomId: String, options: RoomOptions): Room
+
+    /**
+     * Release the Room object if it exists. This method only releases the reference
+     * to the Room object from the Rooms instance and detaches the room from Ably. It does not unsubscribe to any
+     * events.
+     *
+     * After calling this function, the room object is no-longer usable. If you wish to get the room object again,
+     * you must call {@link Rooms.get}.
+     *
+     * @param roomId The ID of the room.
+     */
+    suspend fun release(roomId: String)
+}


### PR DESCRIPTION
Added Rooms interface, that was missing during in public API PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new interface for managing multiple chat rooms, enhancing the chat experience by allowing users to interact with several rooms simultaneously.
	- Added functionality to retrieve and release chat room references, improving memory management and performance.
	- Included options for configuring chat instances, providing users with more customization capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->