### PR TITLE
[ECO-4953][CHA-RL7] RoomLifecycle : Sequential Coroutinescope using select

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/RoomLifecycleManager.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomLifecycleManager.kt
@@ -2,8 +2,6 @@ package com.ably.chat
 
 import io.ably.lib.types.ErrorInfo
 import io.ably.lib.util.Log.LogHandler
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import io.ably.lib.realtime.Channel as AblyRealtimeChannel
 
 /**
@@ -86,15 +84,6 @@ class RoomLifecycleManager
     private val _logger: LogHandler? = logger
 
     /**
-     * sequentialCoroutineScope is to ensure the integrity and atomicity of operations that affect the room status, such as
-     * attaching, detaching, and releasing the room. It makes sure that we don't have multiple operations happening
-     * at once which could leave us in an inconsistent state.
-     * It is used as a CoroutineContext for with [kotlinx.coroutines.selects.select] statement.
-     * See [Kotlin Dispatchers](https://kt.academy/article/cc-dispatchers) for more information.
-     */
-    private val sequentialCoroutineScope = CoroutineScope(Dispatchers.Default.limitedParallelism(1))
-
-    /**
      * This flag indicates whether some sort of controlled operation is in progress (e.g. attaching, detaching, releasing).
      *
      * It is used to prevent the room status from being changed by individual channel state changes and ignore
@@ -114,5 +103,9 @@ class RoomLifecycleManager
             _operationInProgress = true
         }
         // TODO - [CHA-RL4] set up room monitoring here
+    }
+
+    suspend fun attach() {
+        TODO("Not yet implemented")
     }
 }

--- a/chat-android/src/main/java/com/ably/chat/RoomLifecycleManager.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomLifecycleManager.kt
@@ -1,7 +1,15 @@
 package com.ably.chat
 
+import io.ably.lib.types.AblyException
 import io.ably.lib.types.ErrorInfo
 import io.ably.lib.util.Log.LogHandler
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
 import io.ably.lib.realtime.Channel as AblyRealtimeChannel
 
 /**
@@ -84,6 +92,15 @@ class RoomLifecycleManager
     private val _logger: LogHandler? = logger
 
     /**
+     * sequentialCoroutineScope is to ensure the integrity and atomicity of operations that affect the room status, such as
+     * attaching, detaching, and releasing the room. It makes sure that we don't have multiple operations happening
+     * at once which could leave us in an inconsistent state.
+     * It is used as a CoroutineContext for with [kotlinx.coroutines.selects.select] statement.
+     * See [Kotlin Dispatchers](https://kt.academy/article/cc-dispatchers) for more information.
+     */
+    private val sequentialCoroutineScope = CoroutineScope(Dispatchers.Default.limitedParallelism(1))
+
+    /**
      * This flag indicates whether some sort of controlled operation is in progress (e.g. attaching, detaching, releasing).
      *
      * It is used to prevent the room status from being changed by individual channel state changes and ignore
@@ -102,10 +119,115 @@ class RoomLifecycleManager
         if (_status.current != RoomLifecycle.Attached) {
             _operationInProgress = true
         }
+        subscribeToJobEvents()
         // TODO - [CHA-RL4] set up room monitoring here
     }
 
-    suspend fun attach() {
-        TODO("Not yet implemented")
+    enum class OperationType {
+        Internal,
+        Attach,
+        Detach,
+        Release,
+    }
+
+    class RoomOperation<T>(
+        val operationType: OperationType,
+        val coroutineBlock: (suspend CoroutineScope.() -> T),
+        val deferredResult: CompletableDeferred<T>,
+    )
+
+    private val internalEventChannel = Channel<RoomOperation<Any>>(Channel.UNLIMITED)
+    private val releaseEventChannel = Channel<RoomOperation<Any>>(Channel.UNLIMITED)
+    private val attachDetachEventChannel = Channel<RoomOperation<Any>>(Channel.UNLIMITED)
+
+    private suspend fun <T : Any>dispatchRoomOperation(operationType: OperationType, coroutineBlock: suspend (CoroutineScope) -> T):
+        CompletableDeferred<T> {
+        val deferred = CompletableDeferred<Any>()
+        val roomOp = RoomOperation(operationType, coroutineBlock, deferred)
+        when (operationType) {
+            OperationType.Attach -> attachDetachEventChannel.send(roomOp)
+            OperationType.Detach -> TODO()
+            OperationType.Release -> TODO()
+            OperationType.Internal -> TODO()
+        }
+        @Suppress("UNCHECKED_CAST")
+        return deferred as CompletableDeferred<T>
+    }
+
+    internal suspend fun attach() {
+        return dispatchRoomOperation(OperationType.Attach) {
+            when (_status.current) {
+                RoomLifecycle.Attached -> return@dispatchRoomOperation
+                RoomLifecycle.Releasing ->
+                    throw AblyException.fromErrorInfo(
+                        ErrorInfo(
+                            "Can't ATTACH since room is in RELEASING state",
+                            ErrorCodes.RoomIsReleasing.errorCode,
+                        ),
+                    )
+                RoomLifecycle.Released ->
+                    throw AblyException.fromErrorInfo(
+                        ErrorInfo(
+                            "Can't ATTACH since room is in RELEASED state",
+                            ErrorCodes.RoomIsReleased.errorCode,
+                        ),
+                    )
+                else -> {}
+            }
+            doAttach()
+        }.await()
+    }
+
+    /**
+     *
+     * Attaches each feature channel with rollback on channel attach failure.
+     * This method is re-usable and can be called as a part of internal room operations.
+     *
+     */
+    private suspend fun doAttach() {
+        for (feature in _contributors) {
+            feature.channel.attachCoroutine()
+        }
+    }
+
+    /**
+     * Clears all transient detach timeouts - used when some event supersedes the transient detach such
+     * as a failed channel or suspension.
+     */
+    private fun _clearAllTransientDetachTimeouts() {
+        TODO("need to clear all transient detach timeouts")
+    }
+
+    /**
+     * Starts a while loop that runs indefinitely, even after room release.
+     * This is to make sure attach/detach throws exceptions even when room is released.
+     * Check CHA-RL1b, CHA-RL1c, CHA-RL2b, CHA-RL2c, CHA-RL2d.
+     * This also means all available channels can't be closed since we are waiting for processing events.
+     * To avoid this, we have to add extra locking mechanism which should be ideally avoided.
+     */
+    private fun subscribeToJobEvents() {
+        /**
+         * Can't use withContext(coroutineScope), since this is not a suspending function.
+         */
+        sequentialCoroutineScope.launch {
+            while (true) {
+                /**
+                 * The order of precedence for lifecycle operations using select clause allows
+                 * us to ensure that internal operations take precedence over user-driven operations.
+                 * This is as per [LifecycleOperationPrecedence], although that enum won't be used.
+                 * CHA-RL7
+                 */
+                select {
+                    internalEventChannel.onReceive {
+                    }
+                    releaseEventChannel.onReceive {
+                    }
+                    attachDetachEventChannel.onReceive {
+                        val result = async(block = it.coroutineBlock).await()
+                        it.deferredResult.complete(result)
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Implemented RoomLifecycle Atomic Operations with a combination of Sequential Coroutinescope and Select

**Few concerns**
1. On init, runs `subscribeToJobEvents` method which starts a while loop that should run indefinitely, even after room release.
- This is to make sure attach/detach throws exceptions even when room is released.
- Check CHA-RL1b, CHA-RL1c, CHA-RL2b, CHA-RL2c, CHA-RL2d.
- This also means all available channels can't be closed since we are waiting for processing events, this can lead to memory leaks for closed rooms. 
- To avoid this, we have to add an extra locking mechanism which should be ideally avoided.
2. Unfortunately implemenation has become more complicated than we thought because we also need to return the result of the async operation to the calling method i.e. attach, detach, release etc
3. Implementation doesn't sync with chat-js,  which we have maintained till now. We need to introduce additional interfaces. If time comes, it will be a bit difficult to correlate both codebases.

I am not biased towards any kind of implementation, but rather toward simplicity, readability, and usability and how better it aligns with the spec.