### PR TITLE
[ECO-4944] feat: add room level reaction implementation

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/Room.kt
+++ b/chat-android/src/main/java/com/ably/chat/Room.kt
@@ -105,7 +105,8 @@ internal class DefaultRoom(
 
     override val reactions: RoomReactions = DefaultRoomReactions(
         roomId = roomId,
-        realtimeClient = realtimeClient,
+        clientId = realtimeClient.auth.clientId,
+        realtimeChannels = realtimeClient.channels,
     )
 
     override val typing: Typing = DefaultTyping(

--- a/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
@@ -2,7 +2,12 @@
 
 package com.ably.chat
 
+import com.google.gson.JsonObject
+import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.realtime.Channel
+import io.ably.lib.types.AblyException
+import io.ably.lib.types.ErrorInfo
+import io.ably.lib.types.MessageExtras
 
 /**
  * This interface is used to interact with room-level reactions in a chat room: subscribing to reactions and sending them.
@@ -100,19 +105,53 @@ data class SendReactionParams(
 
 internal class DefaultRoomReactions(
     roomId: String,
-    private val realtimeClient: RealtimeClient,
+    private val clientId: String,
+    realtimeChannels: AblyRealtime.Channels,
 ) : RoomReactions {
+    // (CHA-ER1)
     private val roomReactionsChannelName = "$roomId::\$chat::\$reactions"
 
-    override val channel: Channel
-        get() = realtimeClient.channels.get(roomReactionsChannelName, ChatChannelOptions())
+    override val channel: Channel = realtimeChannels.get(roomReactionsChannelName, ChatChannelOptions())
 
+    // (CHA-ER3) Ephemeral room reactions are sent to Ably via the Realtime connection via a send method.
+    // (CHA-ER3a) Reactions are sent on the channel using a message in a particular format - see spec for format.
     override suspend fun send(params: SendReactionParams) {
-        TODO("Not yet implemented")
+        val pubSubMessage = PubSubMessage().apply {
+            data = JsonObject().apply {
+                addProperty("type", params.type)
+                params.metadata?.let { add("metadata", it.toJson()) }
+            }
+            params.headers?.let {
+                extras = MessageExtras(
+                    JsonObject().apply {
+                        add("headers", it.toJson())
+                    },
+                )
+            }
+        }
+        channel.publishCoroutine(pubSubMessage)
     }
 
     override fun subscribe(listener: RoomReactions.Listener): Subscription {
-        TODO("Not yet implemented")
+        val messageListener = PubSubMessageListener {
+            val pubSubMessage = it ?: throw AblyException.fromErrorInfo(
+                ErrorInfo("Got empty pubsub channel message", HttpStatusCodes.BadRequest, ErrorCodes.BadRequest),
+            )
+            val data = pubSubMessage.data as? JsonObject ?: throw AblyException.fromErrorInfo(
+                ErrorInfo("Unrecognized Pub/Sub channel's message for `roomReaction` event", HttpStatusCodes.InternalServerError),
+            )
+            val reaction = Reaction(
+                type = data.requireString("type"),
+                createdAt = pubSubMessage.timestamp,
+                clientId = pubSubMessage.clientId,
+                metadata = data.get("metadata")?.toMap() ?: mapOf(),
+                headers = pubSubMessage.extras.asJsonObject().get("headers")?.toMap() ?: mapOf(),
+                isSelf = pubSubMessage.clientId == clientId,
+            )
+            listener.onReaction(reaction)
+        }
+        channel.subscribe(RoomReactionEventType.Reaction.eventName, messageListener)
+        return Subscription { channel.unsubscribe(RoomReactionEventType.Reaction.eventName, messageListener) }
     }
 
     override fun onDiscontinuity(listener: EmitsDiscontinuities.Listener): Subscription {

--- a/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
@@ -117,6 +117,7 @@ internal class DefaultRoomReactions(
     // (CHA-ER3a) Reactions are sent on the channel using a message in a particular format - see spec for format.
     override suspend fun send(params: SendReactionParams) {
         val pubSubMessage = PubSubMessage().apply {
+            name = RoomReactionEventType.Reaction.eventName
             data = JsonObject().apply {
                 addProperty("type", params.type)
                 params.metadata?.let { add("metadata", it.toJson()) }
@@ -145,7 +146,7 @@ internal class DefaultRoomReactions(
                 createdAt = pubSubMessage.timestamp,
                 clientId = pubSubMessage.clientId,
                 metadata = data.get("metadata")?.toMap() ?: mapOf(),
-                headers = pubSubMessage.extras.asJsonObject().get("headers")?.toMap() ?: mapOf(),
+                headers = pubSubMessage.extras?.asJsonObject()?.get("headers")?.toMap() ?: mapOf(),
                 isSelf = pubSubMessage.clientId == clientId,
             )
             listener.onReaction(reaction)

--- a/chat-android/src/main/java/com/ably/chat/Utils.kt
+++ b/chat-android/src/main/java/com/ably/chat/Utils.kt
@@ -35,6 +35,21 @@ suspend fun Channel.detachCoroutine() = suspendCoroutine { continuation ->
     })
 }
 
+suspend fun Channel.publishCoroutine(message: PubSubMessage) = suspendCoroutine { continuation ->
+    publish(
+        message,
+        object : CompletionListener {
+            override fun onSuccess() {
+                continuation.resume(Unit)
+            }
+
+            override fun onError(reason: ErrorInfo?) {
+                continuation.resumeWithException(AblyException.fromErrorInfo(reason))
+            }
+        },
+    )
+}
+
 @Suppress("FunctionName")
 fun ChatChannelOptions(init: (ChannelOptions.() -> Unit)? = null): ChannelOptions {
     val options = ChannelOptions()

--- a/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/RoomReactionsTest.kt
@@ -1,0 +1,109 @@
+package com.ably.chat
+
+import com.google.gson.JsonObject
+import io.ably.lib.realtime.AblyRealtime.Channels
+import io.ably.lib.realtime.Channel
+import io.ably.lib.realtime.buildRealtimeChannel
+import io.ably.lib.types.MessageExtras
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class RoomReactionsTest {
+    private val realtimeChannels = mockk<Channels>(relaxed = true)
+    private val realtimeChannel = spyk<Channel>(buildRealtimeChannel("room1::\$chat::\$reactions"))
+    private lateinit var roomReactions: DefaultRoomReactions
+
+    @Before
+    fun setUp() {
+        every { realtimeChannels.get(any(), any()) } answers {
+            val channelName = firstArg<String>()
+            if (channelName == "room1::\$chat::\$reactions") {
+                realtimeChannel
+            } else {
+                buildRealtimeChannel(channelName)
+            }
+        }
+
+        roomReactions = DefaultRoomReactions(
+            roomId = "room1",
+            clientId = "client1",
+            realtimeChannels = realtimeChannels,
+        )
+    }
+
+    /**
+     * @spec CHA-ER1
+     */
+    @Test
+    fun `channel name is set according to the spec`() = runTest {
+        val roomReactions = DefaultRoomReactions(
+            roomId = "foo",
+            clientId = "client1",
+            realtimeChannels = realtimeChannels,
+        )
+
+        assertEquals(
+            "foo::\$chat::\$reactions",
+            roomReactions.channel.name,
+        )
+    }
+
+    /**
+     * @spec CHA-ER3a
+     */
+    @Test
+    fun `should be able to subscribe to incoming reactions`() = runTest {
+        val pubSubMessageListenerSlot = slot<PubSubMessageListener>()
+
+        every { realtimeChannel.subscribe("roomReaction", capture(pubSubMessageListenerSlot)) } returns Unit
+
+        val deferredValue = DeferredValue<Reaction>()
+
+        roomReactions.subscribe {
+            deferredValue.completeWith(it)
+        }
+
+        verify { realtimeChannel.subscribe("roomReaction", any()) }
+
+        pubSubMessageListenerSlot.captured.onMessage(
+            PubSubMessage().apply {
+                data = JsonObject().apply {
+                    addProperty("type", "like")
+                }
+                clientId = "clientId"
+                timestamp = 1000L
+                extras = MessageExtras(
+                    JsonObject().apply {
+                        add(
+                            "headers",
+                            JsonObject().apply {
+                                addProperty("foo", "bar")
+                            },
+                        )
+                    },
+                )
+            },
+        )
+
+        val reaction = deferredValue.await()
+
+        assertEquals(
+            Reaction(
+                type = "like",
+                createdAt = 1000L,
+                clientId = "clientId",
+                metadata = mapOf(),
+                headers = mapOf("foo" to "bar"),
+                isSelf = false,
+            ),
+            reaction,
+        )
+    }
+}

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.konfetti.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ ably = "1.2.43"
 junit = "4.13.2"
 agp = "8.5.2"
 detekt = "1.23.6"
+konfetti-compose = "2.0.4"
 kotlin = "2.0.10"
 androidx-test = "1.6.1"
 androidx-junit = "1.2.1"
@@ -43,6 +44,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
+konfetti-compose = { module = "nl.dionsegijn:konfetti-compose", version.ref = "konfetti-compose" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 coroutine-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutine" }


### PR DESCRIPTION
Room level reactions implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `RoomReactions` functionality to allow sending and subscribing to reactions in real-time.
	- Introduced a new coroutine-based method for asynchronous message publishing in the `Channel` class.
	- Added functionality in the chat application to track and display received reactions.

- **Bug Fixes**
	- Improved error handling in the `subscribe` method for incoming messages.

- **Tests**
	- Added unit tests for the `DefaultRoomReactions` class to verify channel naming and subscription behavior.

- **Chores**
	- Integrated the `konfetti` library for use with Jetpack Compose.
	- Updated version management for `konfetti-compose` to version `2.0.4`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->