### PR TITLE
[ECO-5082] feat: presence basic implementation 

### DIFF
--- a/chat-android/build.gradle.kts
+++ b/chat-android/build.gradle.kts
@@ -45,6 +45,7 @@ buildConfig {
 dependencies {
     api(libs.ably.android)
     implementation(libs.gson)
+    implementation(libs.coroutine.core)
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk)

--- a/chat-android/src/main/java/com/ably/chat/Presence.kt
+++ b/chat-android/src/main/java/com/ably/chat/Presence.kt
@@ -31,7 +31,8 @@ interface Presence : EmitsDiscontinuities {
     /**
      *  Method to get list of the current online users and returns the latest presence messages associated to it.
      *  @param {Ably.RealtimePresenceParams} params - Parameters that control how the presence set is retrieved.
-     *  @returns {List<PresenceMessage>} or upon failure, the promise will throw [[Ably.ErrorInfo]] object which explains the error.
+     *  @throws {@link io.ably.lib.types.AblyException} object which explains the error.
+     *  @returns {List<PresenceMessage>}
      */
     suspend fun get(waitForSync: Boolean = true, clientId: String? = null, connectionId: String? = null): List<PresenceMember>
 
@@ -45,21 +46,21 @@ interface Presence : EmitsDiscontinuities {
     /**
      * Method to join room presence, will emit an enter event to all subscribers. Repeat calls will trigger more enter events.
      * @param {PresenceData} data - The users data, a JSON serializable object that will be sent to all subscribers.
-     * @returns {Promise<void>} or upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+     * @throws {@link io.ably.lib.types.AblyException} object which explains the error.
      */
     suspend fun enter(data: PresenceData? = null)
 
     /**
      * Method to update room presence, will emit an update event to all subscribers. If the user is not present, it will be treated as a join event.
      * @param {PresenceData} data - The users data, a JSON serializable object that will be sent to all subscribers.
-     * @returns {Promise<void>} or upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+     * @throws {@link io.ably.lib.types.AblyException} object which explains the error.
      */
     suspend fun update(data: PresenceData? = null)
 
     /**
      * Method to leave room presence, will emit a leave event to all subscribers. If the user is not present, it will be treated as a no-op.
      * @param {PresenceData} data - The users data, a JSON serializable object that will be sent to all subscribers.
-     * @returns {Promise<void>} or upon failure, the promise will be rejected with an {@link ErrorInfo} object which explains the error.
+     * @throws {@link io.ably.lib.types.AblyException} object which explains the error.
      */
     suspend fun leave(data: PresenceData? = null)
 

--- a/chat-android/src/main/java/com/ably/chat/Room.kt
+++ b/chat-android/src/main/java/com/ably/chat/Room.kt
@@ -87,9 +87,11 @@ interface Room {
 internal class DefaultRoom(
     override val roomId: String,
     override val options: RoomOptions,
-    realtimeClient: RealtimeClient,
+    val realtimeClient: RealtimeClient,
     chatApi: ChatApi,
 ) : Room {
+
+    private val clientId get() = realtimeClient.auth.clientId
 
     private val _messages = DefaultMessages(
         roomId = roomId,
@@ -100,12 +102,14 @@ internal class DefaultRoom(
     override val messages: Messages = _messages
 
     override val presence: Presence = DefaultPresence(
-        messages = messages,
+        channel = messages.channel,
+        clientId = clientId,
+        presence = messages.channel.presence,
     )
 
     override val reactions: RoomReactions = DefaultRoomReactions(
         roomId = roomId,
-        clientId = realtimeClient.auth.clientId,
+        clientId = clientId,
         realtimeChannels = realtimeClient.channels,
     )
 

--- a/chat-android/src/test/java/com/ably/chat/PresenceTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/PresenceTest.kt
@@ -1,0 +1,144 @@
+package com.ably.chat
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import io.ably.lib.realtime.Channel
+import io.ably.lib.realtime.Presence.PresenceListener
+import io.ably.lib.realtime.buildRealtimeChannel
+import io.ably.lib.types.PresenceMessage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import io.ably.lib.realtime.Presence as PubSubPresence
+
+class PresenceTest {
+    private val pubSubChannel = spyk<Channel>(buildRealtimeChannel("room1::\$chat::\$messages"))
+    private val pubSubPresence = mockk<PubSubPresence>(relaxed = true)
+    private lateinit var presence: DefaultPresence
+
+    @Before
+    fun setUp() {
+        presence = DefaultPresence(
+            clientId = "client1",
+            channel = pubSubChannel,
+            presence = pubSubPresence,
+        )
+    }
+
+    /**
+     * @spec CHA-PR2a
+     */
+    @Test
+    fun `should transform PresenceMessage into Chat's PresenceEvent if there is no data`() = runTest {
+        val presenceListenerSlot = slot<PresenceListener>()
+
+        every { pubSubPresence.subscribe(capture(presenceListenerSlot)) } returns Unit
+
+        val deferredValue = DeferredValue<PresenceEvent>()
+
+        presence.subscribe {
+            deferredValue.completeWith(it)
+        }
+
+        presenceListenerSlot.captured.onPresenceMessage(
+            PresenceMessage().apply {
+                action = PresenceMessage.Action.leave
+                clientId = "client1"
+                timestamp = 100_000L
+            },
+        )
+
+        val presenceEvent = deferredValue.await()
+
+        assertEquals(
+            PresenceEvent(
+                action = PresenceMessage.Action.leave,
+                clientId = "client1",
+                timestamp = 100_000L,
+                data = null,
+            ),
+            presenceEvent,
+        )
+    }
+
+    /**
+     * @spec CHA-PR2a
+     */
+    @Test
+    fun `should transform PresenceMessage into Chat's PresenceEvent if there is no 'userCustomData'`() = runTest {
+        val presenceListenerSlot = slot<PresenceListener>()
+
+        every { pubSubPresence.subscribe(capture(presenceListenerSlot)) } returns Unit
+
+        val deferredValue = DeferredValue<PresenceEvent>()
+
+        presence.subscribe {
+            deferredValue.completeWith(it)
+        }
+
+        presenceListenerSlot.captured.onPresenceMessage(
+            PresenceMessage().apply {
+                action = PresenceMessage.Action.leave
+                clientId = "client1"
+                timestamp = 100_000L
+                data = JsonObject()
+            },
+        )
+
+        val presenceEvent = deferredValue.await()
+
+        assertEquals(
+            PresenceEvent(
+                action = PresenceMessage.Action.leave,
+                clientId = "client1",
+                timestamp = 100_000L,
+                data = null,
+            ),
+            presenceEvent,
+        )
+    }
+
+    /**
+     * @spec CHA-PR2a
+     */
+    @Test
+    fun `should transform PresenceMessage into Chat's PresenceEvent if 'userCustomData' is primitive`() = runTest {
+        val presenceListenerSlot = slot<PresenceListener>()
+
+        every { pubSubPresence.subscribe(capture(presenceListenerSlot)) } returns Unit
+
+        val deferredValue = DeferredValue<PresenceEvent>()
+
+        presence.subscribe {
+            deferredValue.completeWith(it)
+        }
+
+        presenceListenerSlot.captured.onPresenceMessage(
+            PresenceMessage().apply {
+                action = PresenceMessage.Action.leave
+                clientId = "client1"
+                timestamp = 100_000L
+                data = JsonObject().apply {
+                    addProperty("userCustomData", "user")
+                }
+            },
+        )
+
+        val presenceEvent = deferredValue.await()
+
+        assertEquals(
+            PresenceEvent(
+                action = PresenceMessage.Action.leave,
+                clientId = "client1",
+                timestamp = 100_000L,
+                data = JsonPrimitive("user"),
+            ),
+            presenceEvent,
+        )
+    }
+}

--- a/chat-android/src/test/java/com/ably/chat/SandboxTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/SandboxTest.kt
@@ -1,6 +1,5 @@
 package com.ably.chat
 
-import io.ably.lib.realtime.ChannelState
 import java.util.UUID
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -17,10 +16,22 @@ class SandboxTest {
     }
 
     @Test
-    fun basicIntegrationTest() = runTest {
+    fun `should return empty list of presence members if nobody is entered`() = runTest {
         val chatClient = sandbox.createSandboxChatClient()
         val room = chatClient.rooms.get(UUID.randomUUID().toString())
         room.attach()
-        assertEquals(ChannelState.attached, room.messages.channel.state)
+        val members = room.presence.get()
+        assertEquals(0, members.size)
+    }
+
+    @Test
+    fun `should return yourself as presence member after you entered`() = runTest {
+        val chatClient = sandbox.createSandboxChatClient()
+        val room = chatClient.rooms.get(UUID.randomUUID().toString())
+        room.attach()
+        room.presence.enter()
+        val members = room.presence.get()
+        assertEquals(1, members.size)
+        assertEquals("sandbox-client", members.first().clientId)
     }
 }

--- a/example/src/main/java/com/ably/chat/example/Settings.kt
+++ b/example/src/main/java/com/ably/chat/example/Settings.kt
@@ -1,0 +1,5 @@
+package com.ably.chat.example
+
+object Settings {
+    const val ROOM_ID = "my-room"
+}

--- a/example/src/main/java/com/ably/chat/example/ui/PresencePopup.kt
+++ b/example/src/main/java/com/ably/chat/example/ui/PresencePopup.kt
@@ -1,0 +1,109 @@
+package com.ably.chat.example.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import com.ably.chat.ChatClient
+import com.ably.chat.PresenceMember
+import com.ably.chat.Subscription
+import com.ably.chat.example.Settings
+import com.google.gson.JsonObject
+import kotlinx.coroutines.launch
+
+@SuppressWarnings("LongMethod")
+@Composable
+fun PresencePopup(chatClient: ChatClient, onDismiss: () -> Unit) {
+    var members by remember { mutableStateOf(listOf<PresenceMember>()) }
+    val coroutineScope = rememberCoroutineScope()
+    val presence = chatClient.rooms.get(Settings.ROOM_ID).presence
+
+    DisposableEffect(Unit) {
+        var subscription: Subscription? = null
+
+        coroutineScope.launch {
+            members = presence.get()
+            subscription = presence.subscribe {
+                coroutineScope.launch {
+                    members = presence.get()
+                }
+            }
+        }
+
+        onDispose {
+            subscription?.unsubscribe()
+        }
+    }
+
+    Popup(
+        onDismissRequest = onDismiss,
+    ) {
+        Surface(
+            modifier = Modifier.padding(16.dp),
+            shape = MaterialTheme.shapes.medium,
+            shadowElevation = 8.dp,
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .wrapContentWidth(),
+            ) {
+                Text("Chat Members", style = MaterialTheme.typography.headlineMedium)
+                Spacer(modifier = Modifier.height(8.dp))
+                members.forEach { member ->
+                    BasicText("${member.clientId} - (${(member.data as? JsonObject)?.get("status")?.asString})")
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(onClick = {
+                    coroutineScope.launch {
+                        presence.enter(
+                            JsonObject().apply {
+                                addProperty("status", "online")
+                            },
+                        )
+                    }
+                }) {
+                    Text("Join")
+                }
+                Button(onClick = {
+                    coroutineScope.launch {
+                        presence.enter(
+                            JsonObject().apply {
+                                addProperty("status", "away")
+                            },
+                        )
+                    }
+                }) {
+                    Text("Appear away")
+                }
+                Button(onClick = {
+                    coroutineScope.launch {
+                        presence.leave()
+                    }
+                }) {
+                    Text("Leave")
+                }
+                Button(onClick = onDismiss) {
+                    Text("Close")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
 This implementation doesn’t fully follow the spec; it omits all points that reference the room lifecycle state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new coroutine-based methods for enhanced asynchronous presence management.
	- Added a `PresencePopup` for displaying chat presence information, allowing users to manage their status.
	- Centralized configuration settings with a new `Settings` object, including a constant `ROOM_ID`.

- **Bug Fixes**
	- Updated unit tests to ensure accurate presence member listings in various scenarios.

- **Improvements**
	- Enhanced type specificity in presence data handling.
	- Improved clarity in the `DefaultRoom` class by centralizing `clientId` retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->