### PR TITLE
[CHA-RL3][ECO-5011] Room RELEASE with retry 

### DIFF
--- a/chat-android/src/main/java/com/ably/chat/Occupancy.kt
+++ b/chat-android/src/main/java/com/ably/chat/Occupancy.kt
@@ -80,4 +80,8 @@ internal class DefaultOccupancy(
     override suspend fun get(): OccupancyEvent {
         TODO("Not yet implemented")
     }
+
+    override fun release() {
+        // No need to do anything, since it uses same channel as messages
+    }
 }

--- a/chat-android/src/main/java/com/ably/chat/Presence.kt
+++ b/chat-android/src/main/java/com/ably/chat/Presence.kt
@@ -167,4 +167,8 @@ internal class DefaultPresence(
     override fun subscribe(listener: Presence.Listener): Subscription {
         TODO("Not yet implemented")
     }
+
+    override fun release() {
+        // No need to do anything, since it uses same channel as messages
+    }
 }

--- a/chat-android/src/main/java/com/ably/chat/Room.kt
+++ b/chat-android/src/main/java/com/ably/chat/Room.kt
@@ -105,6 +105,11 @@ interface Room {
      * Detaches from the room to stop receiving events in realtime.
      */
     suspend fun detach()
+
+    /**
+     * Releases the room, underlying channels are removed from the core SDK to prevent leakage.
+     */
+    suspend fun release()
 }
 
 internal class DefaultRoom(
@@ -199,7 +204,7 @@ internal class DefaultRoom(
         reactions.channel.detachCoroutine()
     }
 
-    fun release() {
-        messages.release()
+    override suspend fun release() {
+        _lifecycleManager?.release()
     }
 }

--- a/chat-android/src/main/java/com/ably/chat/RoomLifecycleManager.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomLifecycleManager.kt
@@ -601,7 +601,9 @@ class RoomLifecycleManager(
             }
 
             // If we're already detached, then we can transition to released immediately
-            if (_statusLifecycle.status === RoomStatus.Detached) {
+            if (_statusLifecycle.status === RoomStatus.Detached ||
+                _statusLifecycle.status === RoomStatus.Initialized
+            ) {
                 _statusLifecycle.setStatus(RoomStatus.Released)
                 return@async
             }

--- a/chat-android/src/main/java/com/ably/chat/RoomLifecycleManager.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomLifecycleManager.kt
@@ -40,6 +40,11 @@ interface ContributesToRoomLifecycle : EmitsDiscontinuities, HandlesDiscontinuit
      * @returns The error that should be used when the feature fails to detach.
      */
     val detachmentErrorCode: ErrorCodes
+
+    /**
+     * Underlying Realtime feature channel is removed from the core SDK to prevent leakage.
+     */
+    fun release()
 }
 
 abstract class ContributesToRoomLifecycleImpl : ContributesToRoomLifecycle {
@@ -679,6 +684,9 @@ class RoomLifecycleManager(
                 }
             }
         }.awaitAll()
+        _contributors.forEach {
+            it.contributor.release()
+        }
         _releaseInProgress = false
         _statusLifecycle.setStatus(RoomStatus.Released)
     }

--- a/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
+++ b/chat-android/src/main/java/com/ably/chat/RoomReactions.kt
@@ -106,13 +106,14 @@ data class SendReactionParams(
 internal class DefaultRoomReactions(
     roomId: String,
     private val clientId: String,
-    realtimeChannels: AblyRealtime.Channels,
+    private val realtimeChannels: AblyRealtime.Channels,
 ) : RoomReactions, ContributesToRoomLifecycleImpl(), ResolvedContributor {
+
+    override val featureName = "reactions"
 
     private val roomReactionsChannelName = "$roomId::\$chat::\$reactions"
 
     override val channel: AblyRealtimeChannel = realtimeChannels.get(roomReactionsChannelName, ChatChannelOptions())
-    override val featureName = "reactions"
 
     override val contributor: ContributesToRoomLifecycle = this
 
@@ -160,5 +161,9 @@ internal class DefaultRoomReactions(
         }
         channel.subscribe(RoomReactionEventType.Reaction.eventName, messageListener)
         return Subscription { channel.unsubscribe(RoomReactionEventType.Reaction.eventName, messageListener) }
+    }
+
+    override fun release() {
+        realtimeChannels.release(channel.name)
     }
 }

--- a/chat-android/src/main/java/com/ably/chat/Rooms.kt
+++ b/chat-android/src/main/java/com/ably/chat/Rooms.kt
@@ -72,9 +72,7 @@ internal class DefaultRooms(
     }
 
     override suspend fun release(roomId: String) {
-        synchronized(this) {
-            val room = roomIdToRoom.remove(roomId)
-            room?.release()
-        }
+        val room = roomIdToRoom.remove(roomId)
+        room?.release()
     }
 }

--- a/chat-android/src/main/java/com/ably/chat/Typing.kt
+++ b/chat-android/src/main/java/com/ably/chat/Typing.kt
@@ -107,4 +107,8 @@ internal class DefaultTyping(
     override suspend fun stop() {
         TODO("Not yet implemented")
     }
+
+    override fun release() {
+        realtimeClient.channels.release(channel.name)
+    }
 }

--- a/chat-android/src/main/java/com/ably/chat/Utils.kt
+++ b/chat-android/src/main/java/com/ably/chat/Utils.kt
@@ -57,6 +57,13 @@ val Channel.errorMessage: String
         ", ${reason.message}"
     }
 
+val RoomStatusChange.errorMessage: String
+    get() = if (error == null) {
+        ""
+    } else {
+        ", ${error.message}"
+    }
+
 @Suppress("FunctionName")
 fun ChatChannelOptions(init: (ChannelOptions.() -> Unit)? = null): ChannelOptions {
     val options = ChannelOptions()


### PR DESCRIPTION
Fixed https://github.com/ably-labs/ably-chat-kotlin/issues/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new `release()` methods across various classes for improved resource management.
	- Added an `errorMessage` extension property for enhanced error handling in `RoomStatusChange`.

- **Bug Fixes**
	- Enhanced error handling in message publishing and subscription methods to prevent issues with empty messages.

- **Refactor**
	- Simplified the `release()` method in the `DefaultRooms` class by removing unnecessary synchronization.

- **Documentation**
	- Added comments to clarify the purpose of new methods and existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->