### PR TITLE
[CHA-RL3][ECO-5011] Roomlifecycle RELEASE tests

### DIFF
--- a/chat-android/src/test/java/com/ably/chat/room/ReleaseTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/ReleaseTest.kt
@@ -7,10 +7,15 @@ import com.ably.chat.RoomStatusChange
 import com.ably.chat.assertWaiter
 import com.ably.utils.atomicCoroutineScope
 import com.ably.utils.createRoomFeatureMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.spyk
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
@@ -70,5 +75,55 @@ class ReleaseTest {
         Assert.assertEquals(1, states.size)
         Assert.assertEquals(RoomStatus.Released, states[0].current)
         Assert.assertEquals(RoomStatus.Initialized, states[0].previous)
+    }
+
+    @Test
+    fun `(CHA-RL3c) If room is in Releasing status, op should return result of pending release op`() = runTest {
+        // TODO - need more clarity regarding test case as per https://github.com/ably/ably-chat-js/issues/399
+        // TODO - There might be a need to rephrase the spec statement
+        val statusLifecycle = spyk<DefaultRoomLifecycle>()
+        Assert.assertEquals(RoomStatus.Initializing, statusLifecycle.status)
+
+        val roomLifecycle = spyk(RoomLifecycleManager(roomScope, statusLifecycle, createRoomFeatureMocks()))
+
+        val roomReleased = Channel<Boolean>()
+        var callOriginalRelease = false
+        coEvery {
+            roomLifecycle.release()
+        } coAnswers {
+            roomLifecycle.atomicCoroutineScope().async {
+                if (callOriginalRelease) {
+                    callOriginal()
+                } else {
+                    statusLifecycle.setStatus(RoomStatus.Releasing)
+                    roomReleased.receive()
+                    statusLifecycle.setStatus(RoomStatus.Released)
+                }
+            }
+        }
+
+        // Release op started from separate coroutine
+        launch { roomLifecycle.release() }
+        assertWaiter { !roomLifecycle.atomicCoroutineScope().finishedProcessing }
+        Assert.assertEquals(0, roomLifecycle.atomicCoroutineScope().pendingJobCount) // no queued jobs, release op running
+        assertWaiter { statusLifecycle.status == RoomStatus.Releasing }
+
+        // Original release op started from separate coroutine
+        callOriginalRelease = true
+        val roomReleaseOpDeferred = async { roomLifecycle.release() }
+        assertWaiter { roomLifecycle.atomicCoroutineScope().pendingJobCount == 1 } // release op queued
+        Assert.assertEquals(RoomStatus.Releasing, statusLifecycle.status)
+
+        // Finish previous release op, so new Release op can start
+        roomReleased.send(true)
+        assertWaiter { statusLifecycle.status == RoomStatus.Released }
+
+        val result = kotlin.runCatching { roomReleaseOpDeferred.await() }
+        Assert.assertTrue(result.isSuccess)
+        Assert.assertEquals(RoomStatus.Released, statusLifecycle.status)
+
+        Assert.assertTrue(roomLifecycle.atomicCoroutineScope().finishedProcessing)
+
+        coVerify { roomLifecycle.release() }
     }
 }

--- a/chat-android/src/test/java/com/ably/chat/room/ReleaseTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/ReleaseTest.kt
@@ -1,0 +1,55 @@
+package com.ably.chat.room
+
+import com.ably.chat.DefaultRoomLifecycle
+import com.ably.chat.RoomLifecycleManager
+import com.ably.chat.RoomStatus
+import com.ably.chat.RoomStatusChange
+import com.ably.chat.assertWaiter
+import com.ably.utils.atomicCoroutineScope
+import com.ably.utils.createRoomFeatureMocks
+import io.mockk.spyk
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ * Spec: CHA-RL3
+ */
+class ReleaseTest {
+    private val roomScope = CoroutineScope(
+        Dispatchers.Default.limitedParallelism(1) + CoroutineName("roomId"),
+    )
+
+    @Test
+    fun `(CHA-RL3a) Release success when room is already in released state`() = runTest {
+        val statusLifecycle = spyk<DefaultRoomLifecycle>().apply {
+            setStatus(RoomStatus.Released)
+        }
+        val roomLifecycle = spyk(RoomLifecycleManager(roomScope, statusLifecycle, createRoomFeatureMocks()))
+        val result = kotlin.runCatching { roomLifecycle.release() }
+        Assert.assertTrue(result.isSuccess)
+        assertWaiter { roomLifecycle.atomicCoroutineScope().finishedProcessing }
+    }
+
+    @Test
+    fun `(CHA-RL3b) If room is in detached state, room is immediately transitioned to released`() = runTest {
+        val statusLifecycle = spyk<DefaultRoomLifecycle>().apply {
+            setStatus(RoomStatus.Detached)
+        }
+        val states = mutableListOf<RoomStatusChange>()
+        statusLifecycle.onChange {
+            states.add(it)
+        }
+        val roomLifecycle = spyk(RoomLifecycleManager(roomScope, statusLifecycle, createRoomFeatureMocks()))
+
+        val result = kotlin.runCatching { roomLifecycle.release() }
+        Assert.assertTrue(result.isSuccess)
+        assertWaiter { roomLifecycle.atomicCoroutineScope().finishedProcessing }
+        Assert.assertEquals(1, states.size)
+        Assert.assertEquals(RoomStatus.Released, states[0].current)
+        Assert.assertEquals(RoomStatus.Detached, states[0].previous)
+    }
+}


### PR DESCRIPTION
TODO's

- [x] (CHA-RL3a) [Testable] If the room is already in the RELEASED status, this operation is no-op.
- [x] (CHA-RL3b) [Testable] If the room is in the DETACHED status, then the room is immediately transitioned to RELEASED and the operation succeeds.
- [x] (CHA-RL3j) [Testable] If the room is in the INITIALIZED status, then the room is immediately transitioned to RELEASED and the operation succeeds.
- [x] (CHA-RL3c) [Testable] If the room is in the RELEASING status, then the operation will return the result of the pending release operation, or throw any exception that it throws.
- [x] (CHA-RL3l) [Testable] When the release operation commences, the room will transition into the RELEASING status and any transient disconnect timeouts shall be cleared.
- [x] (CHA-RL3d) [Testable] All features channels must be detached in sequence.
- [x] (CHA-RL3e) [Testable] If a channel is in the FAILED state when it is time to detach, it shall be ignored.
- [x] (CHA-RL3f) [Testable] If a channel fails to detach (i.e. the call to detach() returns an error), the CHA-RL3d channel detach sequence will be retried after a 250ms delay. Retries are continued until CHA-RL3g is met.
- [x] (CHA-RL3g) [Testable] Once all channels have entered the DETACHED (i.e. the call to detach() succeeds) or FAILED (i.e. the call to detach() fails and the channel state is subsequently FAILED) state, then the room state is transitioned to RELEASED and the operation completes.
- [x] (CHA-RL3h) [Testable] Upon operation completion, the underlying Realtime Channels are released from the core SDK prevent leakage.
- [x] (CHA-RL3k) [Testable] If a room lifecycle operation is already in progress, this operation shall wait until the current operation completes before continuing, subject to CHA-RL7.
- [x] Annotate code with relevant spec 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced room lifecycle management with improved release process and error handling.
	- Added comprehensive unit tests for the room release functionality.

- **Bug Fixes**
	- Improved robustness of the room's transition to the released state from various conditions.

- **Documentation**
	- Added comments and specifications for clarity in the release process and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->