### PR TITLE
[CHA-RL5][ECO-5012] Implement Room Retry tests

### DIFF
--- a/chat-android/src/test/java/com/ably/chat/TestUtils.kt
+++ b/chat-android/src/test/java/com/ably/chat/TestUtils.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 
@@ -76,4 +77,12 @@ fun <T>Any.getPrivateField(name: String): T {
     valueField.isAccessible = true
     @Suppress("UNCHECKED_CAST")
     return valueField.get(this) as T
+}
+
+suspend fun <T>Any.invokePrivateSuspendMethod(methodName: String, vararg args: Any?) = suspendCancellableCoroutine<T> { cont ->
+    val suspendMethod = javaClass.declaredMethods.find { it.name == methodName }
+    suspendMethod?.let {
+        it.isAccessible = true
+        it.invoke(this, *args, cont)
+    }
 }

--- a/chat-android/src/test/java/com/ably/chat/room/PrecedenceTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/PrecedenceTest.kt
@@ -1,6 +1,117 @@
 package com.ably.chat.room
 
+import com.ably.chat.DefaultRoomAttachmentResult
+import com.ably.chat.DefaultRoomLifecycle
+import com.ably.chat.ResolvedContributor
+import com.ably.chat.RoomLifecycleManager
+import com.ably.chat.RoomStatus
+import com.ably.chat.RoomStatusChange
+import com.ably.chat.assertWaiter
+import com.ably.utils.atomicCoroutineScope
+import com.ably.utils.atomicRetry
+import com.ably.utils.createRoomFeatureMocks
+import io.mockk.coEvery
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.Assert
+import org.junit.Test
+
 /**
+ * Room lifecycle operations are atomic and exclusive operations: one operation must complete (whether that’s failure or success) before the next one may begin.
  * Spec: CHA-RL7
  */
-class PrecedenceTest
+class PrecedenceTest {
+    private val roomScope = CoroutineScope(
+        Dispatchers.Default.limitedParallelism(1) + CoroutineName("roomId"),
+    )
+
+    /**
+     * 1. RETRY (CHA-RL7a1) - Internal operation.
+     * 2. RELEASE (CHA-RL7a2) - External operation.
+     * 3. ATTACH or DETACH (CHA-RL7a3) - External operation.
+     */
+    @Suppress("LongMethod")
+    @Test
+    fun `(CHA-RL7a) If multiple operations are scheduled to run, they run as per LifecycleOperationPrecedence`() = runTest {
+        val statusLifecycle = spyk<DefaultRoomLifecycle>()
+        val roomStatusChanges = mutableListOf<RoomStatusChange>()
+        statusLifecycle.onChange {
+            roomStatusChanges.add(it)
+        }
+
+        val contributors = createRoomFeatureMocks("1234")
+        Assert.assertEquals(5, contributors.size)
+
+        val roomLifecycle = spyk(RoomLifecycleManager(roomScope, statusLifecycle, contributors), recordPrivateCalls = true)
+        // Internal operation
+        coEvery { roomLifecycle["doRetry"](any<ResolvedContributor>()) } coAnswers {
+            delay(200)
+            statusLifecycle.setStatus(RoomStatus.Suspended)
+            statusLifecycle.setStatus(RoomStatus.Failed)
+            error("throwing error to avoid continuation getting stuck :( ")
+        }
+        // Attach operation
+        coEvery { roomLifecycle invokeNoArgs "doAttach" } coAnswers {
+            delay(500)
+            statusLifecycle.setStatus(RoomStatus.Attached)
+            DefaultRoomAttachmentResult()
+        }
+        // Detach operation
+        coEvery { roomLifecycle invokeNoArgs "doDetach" } coAnswers {
+            delay(200)
+            statusLifecycle.setStatus(RoomStatus.Detached)
+        }
+        // Release operation
+        coEvery { roomLifecycle invokeNoArgs "releaseChannels" } coAnswers {
+            delay(200)
+            statusLifecycle.setStatus(RoomStatus.Released)
+        }
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            launch {
+                roomLifecycle.attach()
+            }
+            assertWaiter { !roomLifecycle.atomicCoroutineScope().finishedProcessing } // Get attach into processing
+            launch {
+                kotlin.runCatching { roomLifecycle.detach() } // Attach in process, Queue -> Detach
+            }
+            launch {
+                kotlin.runCatching { roomLifecycle.atomicRetry(contributors[0]) } // Attach in process, Queue -> Retry, Detach
+            }
+            launch {
+                kotlin.runCatching { roomLifecycle.attach() } // Attach in process, Queue -> Retry, Detach, Attach
+            }
+
+            // Because of release, detach and attach won't be able to execute their operations
+            launch {
+                roomLifecycle.release() // Attach in process, Queue -> Retry, Release, Detach, Attach
+            }
+        }
+
+        assertWaiter { roomLifecycle.atomicCoroutineScope().finishedProcessing }
+
+        Assert.assertEquals(6, roomStatusChanges.size)
+        Assert.assertEquals(RoomStatus.Attaching, roomStatusChanges[0].current)
+        Assert.assertEquals(RoomStatus.Attached, roomStatusChanges[1].current)
+        Assert.assertEquals(RoomStatus.Suspended, roomStatusChanges[2].current)
+        Assert.assertEquals(RoomStatus.Failed, roomStatusChanges[3].current)
+        Assert.assertEquals(RoomStatus.Releasing, roomStatusChanges[4].current)
+        Assert.assertEquals(RoomStatus.Released, roomStatusChanges[5].current)
+
+        verify {
+            roomLifecycle["doRetry"](any<ResolvedContributor>())
+            roomLifecycle invokeNoArgs "doAttach"
+            roomLifecycle invokeNoArgs "releaseChannels"
+        }
+
+        verify(exactly = 0) {
+            roomLifecycle invokeNoArgs "doDetach"
+        }
+    }
+}

--- a/chat-android/src/test/java/com/ably/chat/room/PrecedenceTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/PrecedenceTest.kt
@@ -1,0 +1,6 @@
+package com.ably.chat.room
+
+/**
+ * Spec: CHA-RL7
+ */
+class PrecedenceTest

--- a/chat-android/src/test/java/com/ably/chat/room/RetryTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RetryTest.kt
@@ -1,0 +1,6 @@
+package com.ably.chat.room
+
+/**
+ * Spec: CHA-RL5
+ */
+class RetryTest

--- a/chat-android/src/test/java/com/ably/chat/room/RetryTest.kt
+++ b/chat-android/src/test/java/com/ably/chat/room/RetryTest.kt
@@ -11,10 +11,14 @@ import com.ably.utils.createRoomFeatureMocks
 import com.ably.utils.retry
 import com.ably.utils.setState
 import io.ably.lib.realtime.ChannelState
+import io.ably.lib.realtime.ChannelStateListener
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockkStatic
 import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -63,12 +67,99 @@ class RetryTest {
 
     @Suppress("MaximumLineLength")
     @Test
+    fun `(CHA-RL5c) If one of the contributor channel goes into failed state during channel windown (CHA-RL5a), then the room enters failed state and retry operation stops`() = runTest {
+        val statusLifecycle = spyk<DefaultRoomLifecycle>()
+
+        mockkStatic(io.ably.lib.realtime.Channel::attachCoroutine)
+        coJustRun { any<io.ably.lib.realtime.Channel>().attachCoroutine() }
+
+        coEvery { any<io.ably.lib.realtime.Channel>().detachCoroutine() } coAnswers {
+            val channel = firstArg<io.ably.lib.realtime.Channel>()
+            if (channel.name.contains("typing")) {
+                channel.setState(ChannelState.failed)
+                error("${channel.name} went into FAILED state")
+            }
+        }
+
+        val contributors = createRoomFeatureMocks()
+
+        val messagesContributor = contributors.first { it.contributor.featureName == "messages" }
+        messagesContributor.channel.setState(ChannelState.attached)
+
+        val roomLifecycle = spyk(RoomLifecycleManager(roomScope, statusLifecycle, contributors))
+
+        val result = kotlin.runCatching { roomLifecycle.retry(messagesContributor) }
+        Assert.assertTrue(result.isFailure)
+        Assert.assertEquals(RoomStatus.Failed, statusLifecycle.status)
+
+        assertWaiter { roomLifecycle.atomicCoroutineScope().finishedProcessing }
+    }
+
+    @Suppress("MaximumLineLength")
+    @Test
     fun `(CHA-RL5c) If one of the contributor channel goes into failed state during Retry, then the room enters failed state and retry operation stops`() = runTest {
+        val statusLifecycle = spyk<DefaultRoomLifecycle>()
+
+        mockkStatic(io.ably.lib.realtime.Channel::attachCoroutine)
+        coJustRun { any<io.ably.lib.realtime.Channel>().detachCoroutine() }
+
+        coEvery { any<io.ably.lib.realtime.Channel>().attachCoroutine() } coAnswers {
+            val channel = firstArg<io.ably.lib.realtime.Channel>()
+            if (channel.name.contains("typing")) {
+                channel.setState(ChannelState.failed)
+                error("${channel.name} went into FAILED state")
+            }
+        }
+
+        val contributors = createRoomFeatureMocks()
+
+        val messagesContributor = contributors.first { it.contributor.featureName == "messages" }
+        messagesContributor.channel.setState(ChannelState.attached)
+
+        val roomLifecycle = spyk(RoomLifecycleManager(roomScope, statusLifecycle, contributors))
+
+        roomLifecycle.retry(messagesContributor)
+        Assert.assertEquals(RoomStatus.Failed, statusLifecycle.status)
+
+        assertWaiter { roomLifecycle.atomicCoroutineScope().finishedProcessing }
     }
 
     @Suppress("MaximumLineLength")
     @Test
     fun `(CHA-RL5d) If all contributor channels goes into detached (except one provided in suspended state), provided contributor starts attach operation and waits for ATTACHED or FAILED state`() = runTest {
+        val statusLifecycle = spyk<DefaultRoomLifecycle>()
+
+        mockkStatic(io.ably.lib.realtime.Channel::attachCoroutine)
+        coJustRun { any<io.ably.lib.realtime.Channel>().attachCoroutine() }
+        coJustRun { any<io.ably.lib.realtime.Channel>().detachCoroutine() }
+
+        val contributors = createRoomFeatureMocks()
+        val messagesContributor = contributors.first { it.contributor.featureName == "messages" }
+
+        every {
+            messagesContributor.channel.once(eq(ChannelState.attached), any<ChannelStateListener>())
+        } answers {
+            secondArg<ChannelStateListener>().onChannelStateChanged(null)
+        }
+        justRun {
+            messagesContributor.channel.once(eq(ChannelState.failed), any<ChannelStateListener>())
+        }
+
+        val roomLifecycle = spyk(RoomLifecycleManager(roomScope, statusLifecycle, contributors))
+
+        val result = kotlin.runCatching { roomLifecycle.retry(messagesContributor) }
+
+        Assert.assertTrue(result.isSuccess)
+        Assert.assertEquals(RoomStatus.Attached, statusLifecycle.status)
+
+        assertWaiter { roomLifecycle.atomicCoroutineScope().finishedProcessing }
+
+        verify {
+            messagesContributor.channel.once(eq(ChannelState.attached), any<ChannelStateListener>())
+        }
+        verify {
+            messagesContributor.channel.once(eq(ChannelState.failed), any<ChannelStateListener>())
+        }
     }
 
     @Suppress("MaximumLineLength")

--- a/chat-android/src/test/java/com/ably/utils/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/utils/RoomTestHelpers.kt
@@ -7,6 +7,7 @@ import com.ably.chat.DefaultOccupancy
 import com.ably.chat.DefaultPresence
 import com.ably.chat.DefaultRoomReactions
 import com.ably.chat.DefaultTyping
+import com.ably.chat.LifecycleOperationPrecedence
 import com.ably.chat.ResolvedContributor
 import com.ably.chat.RoomLifecycleManager
 import com.ably.chat.getPrivateField
@@ -23,6 +24,12 @@ fun RoomLifecycleManager.atomicCoroutineScope(): AtomicCoroutineScope = getPriva
 
 suspend fun RoomLifecycleManager.retry(exceptContributor: ResolvedContributor) =
     invokePrivateSuspendMethod<Unit>("doRetry", exceptContributor)
+
+suspend fun RoomLifecycleManager.atomicRetry(exceptContributor: ResolvedContributor) {
+    atomicCoroutineScope().async(LifecycleOperationPrecedence.Internal.priority) {
+        retry(exceptContributor)
+    }.await()
+}
 
 fun AblyRealtimeChannel.setState(state: ChannelState, errorInfo: ErrorInfo? = null) {
     this.state = state

--- a/chat-android/src/test/java/com/ably/utils/RoomTestHelpers.kt
+++ b/chat-android/src/test/java/com/ably/utils/RoomTestHelpers.kt
@@ -10,6 +10,7 @@ import com.ably.chat.DefaultTyping
 import com.ably.chat.ResolvedContributor
 import com.ably.chat.RoomLifecycleManager
 import com.ably.chat.getPrivateField
+import com.ably.chat.invokePrivateSuspendMethod
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.types.ClientOptions
@@ -19,6 +20,9 @@ import io.mockk.spyk
 import io.ably.lib.realtime.Channel as AblyRealtimeChannel
 
 fun RoomLifecycleManager.atomicCoroutineScope(): AtomicCoroutineScope = getPrivateField("atomicCoroutineScope")
+
+suspend fun RoomLifecycleManager.retry(exceptContributor: ResolvedContributor) =
+    invokePrivateSuspendMethod<Unit>("doRetry", exceptContributor)
 
 fun AblyRealtimeChannel.setState(state: ChannelState, errorInfo: ErrorInfo? = null) {
     this.state = state


### PR DESCRIPTION
Fixed #24 
TODOs
- [x] (CHA-RL5a) [Testable] When entering a RETRY operation, the room must first DETACH all contributors underlying realtime channels using a CHA-RL2f detachment cycle, with the exception of the channel that became SUSPENDED.
- [x] (CHA-RL5a1) NOTE: As many chat features share channels, the equality of contributors when deciding not to detach is based on their realtime channel, and not the contributor themselves. i.e. if two features share a realtime channel, and that channel is suspended, then that channel should not be detached.
- [x] (CHA-RL5b) This specification point has been removed.
- [x] (CHA-RL5c) [Testable] If the operation above fails (i.e. the call to the CHA-RL2f detach procedure fails), such that the room enters the FAILED state, then the retry loop must stop.
- [x] (CHA-RL5d) Once all channels (except the channel that entered SUSPENDED, per CHA-RL5a) have been detached, the room waits until the original channel that caused the retry loop naturally enters the ATTACHED state. Automatic re-attachment is handled by the underlying Realtime SDK. Upon completion of the CHA-RL5a detach procedure, the SDK must check if the channel has already entered a new state. If not, it shall subscribe to channel state updates to be notified.
- [x] (CHA-RL5e) [Testable] If, during the CHA-RL5d wait, the channel state becomes FAILED (either by being in that state after the CHA-RL5a detach procedure completes, or via a state change event), then the room status is transitioned to FAILED and the retry loop stops. The error associated with the transition is the error from the Realtime ChannelStateChange.
- [x] (CHA-RL5f) [Testable] If, during the CHA-RL5d wait, the channel state becomes ATTACHED (either by being in that state after the CHA-RL5a detach procedure completes, or via a state change event), then the room status is transitioned to ATTACHING to begin a new CHA-RL1e attachment cycle. On successful completion, or terminal condition (room status is FAILED) the RETRY loop terminates.
- [x] (CHA-RL7) Implement Room lifecycle precedence tests as per https://github.com/ably-labs/ably-chat-kotlin/issues/34
- [x] Annotate spec with relevant spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and control flow for room lifecycle operations.
	- Introduced a new suspend function `retry` for asynchronous retry logic in the `RoomLifecycleManager`.
	- Added a utility function to invoke private suspend methods reflectively.

- **Tests**
	- Added comprehensive unit tests for retry mechanisms in the `RoomLifecycleManager`, validating channel attachment and detachment scenarios.
	- Introduced new test classes for structured testing of room lifecycle behaviors, ensuring operations occur in the correct order.

- **Documentation**
	- Improved code comments for better clarity and maintainability regarding room lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->