### PR TITLE
refactor!: replace Gson with custom Json implementation

### DIFF
--- a/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/PresenceTest.kt
+++ b/chat-extensions-compose/src/test/kotlin/com/ably/chat/extensions/compose/PresenceTest.kt
@@ -12,7 +12,7 @@ import com.ably.chat.Room
 import com.ably.chat.RoomStatus
 import com.ably.chat.Subscription
 import com.ably.chat.annotations.ExperimentalChatApi
-import com.google.gson.JsonObject
+import com.ably.chat.json.JsonObject
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.sync.Mutex

--- a/chat/api/android/chat.api
+++ b/chat/api/android/chat.api
@@ -141,7 +141,7 @@ public abstract interface class com/ably/chat/Message {
 	public abstract fun getClientId ()Ljava/lang/String;
 	public abstract fun getCreatedAt ()J
 	public abstract fun getHeaders ()Ljava/util/Map;
-	public abstract fun getMetadata ()Lcom/google/gson/JsonObject;
+	public abstract fun getMetadata ()Lcom/ably/chat/json/JsonObject;
 	public abstract fun getOperation ()Lio/ably/lib/types/Message$Operation;
 	public abstract fun getReactions ()Lcom/ably/chat/MessageReactions;
 	public abstract fun getSerial ()Ljava/lang/String;
@@ -151,8 +151,8 @@ public abstract interface class com/ably/chat/Message {
 }
 
 public final class com/ably/chat/MessageKt {
-	public static final fun copy (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/google/gson/JsonObject;)Lcom/ably/chat/Message;
-	public static synthetic fun copy$default (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/google/gson/JsonObject;ILjava/lang/Object;)Lcom/ably/chat/Message;
+	public static final fun copy (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/ably/chat/json/JsonObject;)Lcom/ably/chat/Message;
+	public static synthetic fun copy$default (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/ably/chat/json/JsonObject;ILjava/lang/Object;)Lcom/ably/chat/Message;
 	public static final fun with (Lcom/ably/chat/Message;Lcom/ably/chat/ChatMessageEvent;)Lcom/ably/chat/Message;
 	public static final fun with (Lcom/ably/chat/Message;Lcom/ably/chat/MessageReactionSummaryEvent;)Lcom/ably/chat/Message;
 }
@@ -226,7 +226,7 @@ public abstract interface class com/ably/chat/Messages {
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun getReactions ()Lcom/ably/chat/MessagesReactions;
 	public abstract fun history (Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun send (Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Messages$Listener;)Lcom/ably/chat/MessagesSubscription;
 	public abstract fun update (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -234,7 +234,7 @@ public abstract interface class com/ably/chat/Messages {
 public final class com/ably/chat/Messages$DefaultImpls {
 	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun history$default (Lcom/ably/chat/Messages;Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun update$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -395,20 +395,20 @@ public abstract interface class com/ably/chat/PaginatedResult {
 }
 
 public abstract interface class com/ably/chat/Presence {
-	public abstract fun enter (Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun enter (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun get (ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun isUserPresent (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun leave (Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun leave (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Presence$Listener;)Lcom/ably/chat/Subscription;
-	public abstract fun update (Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun update (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/ably/chat/Presence$DefaultImpls {
-	public static synthetic fun enter$default (Lcom/ably/chat/Presence;Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun enter$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcom/ably/chat/Presence;ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun leave$default (Lcom/ably/chat/Presence;Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun update$default (Lcom/ably/chat/Presence;Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun leave$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun update$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/Presence$Listener {
@@ -438,8 +438,8 @@ public final class com/ably/chat/PresenceKt {
 public abstract interface class com/ably/chat/PresenceMember {
 	public abstract fun getClientId ()Ljava/lang/String;
 	public abstract fun getConnectionId ()Ljava/lang/String;
-	public abstract fun getData ()Lcom/google/gson/JsonElement;
-	public abstract fun getExtras ()Lcom/google/gson/JsonObject;
+	public abstract fun getData ()Lcom/ably/chat/json/JsonObject;
+	public abstract fun getExtras ()Lcom/ably/chat/json/JsonObject;
 	public abstract fun getUpdatedAt ()J
 }
 
@@ -509,7 +509,7 @@ public abstract interface class com/ably/chat/RoomReaction {
 	public abstract fun getClientId ()Ljava/lang/String;
 	public abstract fun getCreatedAt ()J
 	public abstract fun getHeaders ()Ljava/util/Map;
-	public abstract fun getMetadata ()Lcom/google/gson/JsonObject;
+	public abstract fun getMetadata ()Lcom/ably/chat/json/JsonObject;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun isSelf ()Z
 }
@@ -529,12 +529,12 @@ public final class com/ably/chat/RoomReactionEventType : java/lang/Enum {
 
 public abstract interface class com/ably/chat/RoomReactions {
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
-	public abstract fun send (Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/RoomReactions$Listener;)Lcom/ably/chat/Subscription;
 }
 
 public final class com/ably/chat/RoomReactions$DefaultImpls {
-	public static synthetic fun send$default (Lcom/ably/chat/RoomReactions;Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/RoomReactions;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/RoomReactions$Listener {
@@ -645,5 +645,158 @@ public abstract interface annotation class com/ably/chat/annotations/ChatDsl : j
 }
 
 public abstract interface annotation class com/ably/chat/annotations/ExperimentalChatApi : java/lang/annotation/Annotation {
+}
+
+public final class com/ably/chat/json/JsonArray : com/ably/chat/json/JsonValue, java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun add (ILcom/ably/chat/json/JsonValue;)V
+	public synthetic fun add (ILjava/lang/Object;)V
+	public fun add (Lcom/ably/chat/json/JsonValue;)Z
+	public synthetic fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Lcom/ably/chat/json/JsonValue;)Z
+	public final fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public fun get (I)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun get (I)Ljava/lang/Object;
+	public fun getSize ()I
+	public fun hashCode ()I
+	public fun indexOf (Lcom/ably/chat/json/JsonValue;)I
+	public final fun indexOf (Ljava/lang/Object;)I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public fun lastIndexOf (Lcom/ably/chat/json/JsonValue;)I
+	public final fun lastIndexOf (Ljava/lang/Object;)I
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public fun remove (I)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun remove (I)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILcom/ably/chat/json/JsonValue;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun size ()I
+	public fun sort (Ljava/util/Comparator;)V
+	public fun subList (II)Ljava/util/List;
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ably/chat/json/JsonArrayBuilder {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun add (Ljava/lang/Object;)Lcom/ably/chat/json/JsonArrayBuilder;
+	public final fun addArray (Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonArrayBuilder;
+	public final fun addObject (Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonArrayBuilder;
+}
+
+public final class com/ably/chat/json/JsonBoolean : com/ably/chat/json/JsonValue {
+	public fun <init> (Z)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ably/chat/json/JsonBuilderKt {
+	public static final fun jsonArray (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonArray;
+	public static synthetic fun jsonArray$default (Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/ably/chat/json/JsonArray;
+	public static final fun jsonObject (Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonObject;
+	public static synthetic fun jsonObject$default (Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/ably/chat/json/JsonObject;
+}
+
+public final class com/ably/chat/json/JsonNull : com/ably/chat/json/JsonValue {
+	public static final field INSTANCE Lcom/ably/chat/json/JsonNull;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ably/chat/json/JsonNumber : com/ably/chat/json/JsonValue {
+	public fun <init> (Ljava/lang/Number;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ably/chat/json/JsonObject : com/ably/chat/json/JsonValue, java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clear ()V
+	public synthetic fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun compute (Ljava/lang/String;Ljava/util/function/BiFunction;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
+	public fun computeIfAbsent (Ljava/lang/String;Ljava/util/function/Function;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun computeIfPresent (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun computeIfPresent (Ljava/lang/String;Ljava/util/function/BiFunction;)Lcom/ably/chat/json/JsonValue;
+	public final fun containsKey (Ljava/lang/Object;)Z
+	public fun containsKey (Ljava/lang/String;)Z
+	public fun containsValue (Lcom/ably/chat/json/JsonValue;)Z
+	public final fun containsValue (Ljava/lang/Object;)Z
+	public final fun entrySet ()Ljava/util/Set;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (Ljava/lang/Object;)Lcom/ably/chat/json/JsonValue;
+	public final synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun get (Ljava/lang/String;)Lcom/ably/chat/json/JsonValue;
+	public fun getEntries ()Ljava/util/Set;
+	public fun getKeys ()Ljava/util/Set;
+	public fun getSize ()I
+	public fun getValues ()Ljava/util/Collection;
+	public fun hashCode ()I
+	public fun isEmpty ()Z
+	public final fun keySet ()Ljava/util/Set;
+	public synthetic fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun merge (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;Ljava/util/function/BiFunction;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun put (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;)Lcom/ably/chat/json/JsonValue;
+	public fun putAll (Ljava/util/Map;)V
+	public synthetic fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putIfAbsent (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;)Lcom/ably/chat/json/JsonValue;
+	public fun remove (Ljava/lang/Object;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replace (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;)Lcom/ably/chat/json/JsonValue;
+	public fun replace (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;Lcom/ably/chat/json/JsonValue;)Z
+	public fun replaceAll (Ljava/util/function/BiFunction;)V
+	public final fun size ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun values ()Ljava/util/Collection;
+}
+
+public final class com/ably/chat/json/JsonObjectBuilder {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun put (Ljava/lang/String;Ljava/lang/Object;)Lcom/ably/chat/json/JsonObjectBuilder;
+	public final fun putArray (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonObjectBuilder;
+	public final fun putObject (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonObjectBuilder;
+}
+
+public final class com/ably/chat/json/JsonString : com/ably/chat/json/JsonValue {
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ably/chat/json/JsonValue {
+	public static final field Companion Lcom/ably/chat/json/JsonValue$Companion;
+}
+
+public final class com/ably/chat/json/JsonValue$Companion {
 }
 

--- a/chat/api/jvm/chat.api
+++ b/chat/api/jvm/chat.api
@@ -141,7 +141,7 @@ public abstract interface class com/ably/chat/Message {
 	public abstract fun getClientId ()Ljava/lang/String;
 	public abstract fun getCreatedAt ()J
 	public abstract fun getHeaders ()Ljava/util/Map;
-	public abstract fun getMetadata ()Lcom/google/gson/JsonObject;
+	public abstract fun getMetadata ()Lcom/ably/chat/json/JsonObject;
 	public abstract fun getOperation ()Lio/ably/lib/types/Message$Operation;
 	public abstract fun getReactions ()Lcom/ably/chat/MessageReactions;
 	public abstract fun getSerial ()Ljava/lang/String;
@@ -151,8 +151,8 @@ public abstract interface class com/ably/chat/Message {
 }
 
 public final class com/ably/chat/MessageKt {
-	public static final fun copy (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/google/gson/JsonObject;)Lcom/ably/chat/Message;
-	public static synthetic fun copy$default (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/google/gson/JsonObject;ILjava/lang/Object;)Lcom/ably/chat/Message;
+	public static final fun copy (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/ably/chat/json/JsonObject;)Lcom/ably/chat/Message;
+	public static synthetic fun copy$default (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lcom/ably/chat/json/JsonObject;ILjava/lang/Object;)Lcom/ably/chat/Message;
 	public static final fun with (Lcom/ably/chat/Message;Lcom/ably/chat/ChatMessageEvent;)Lcom/ably/chat/Message;
 	public static final fun with (Lcom/ably/chat/Message;Lcom/ably/chat/MessageReactionSummaryEvent;)Lcom/ably/chat/Message;
 }
@@ -226,7 +226,7 @@ public abstract interface class com/ably/chat/Messages {
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun getReactions ()Lcom/ably/chat/MessagesReactions;
 	public abstract fun history (Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun send (Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Messages$Listener;)Lcom/ably/chat/MessagesSubscription;
 	public abstract fun update (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -234,7 +234,7 @@ public abstract interface class com/ably/chat/Messages {
 public final class com/ably/chat/Messages$DefaultImpls {
 	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun history$default (Lcom/ably/chat/Messages;Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun update$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -395,20 +395,20 @@ public abstract interface class com/ably/chat/PaginatedResult {
 }
 
 public abstract interface class com/ably/chat/Presence {
-	public abstract fun enter (Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun enter (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun get (ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun isUserPresent (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun leave (Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun leave (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Presence$Listener;)Lcom/ably/chat/Subscription;
-	public abstract fun update (Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun update (Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/ably/chat/Presence$DefaultImpls {
-	public static synthetic fun enter$default (Lcom/ably/chat/Presence;Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun enter$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcom/ably/chat/Presence;ZLjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun leave$default (Lcom/ably/chat/Presence;Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun update$default (Lcom/ably/chat/Presence;Lcom/google/gson/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun leave$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun update$default (Lcom/ably/chat/Presence;Lcom/ably/chat/json/JsonObject;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/Presence$Listener {
@@ -438,8 +438,8 @@ public final class com/ably/chat/PresenceKt {
 public abstract interface class com/ably/chat/PresenceMember {
 	public abstract fun getClientId ()Ljava/lang/String;
 	public abstract fun getConnectionId ()Ljava/lang/String;
-	public abstract fun getData ()Lcom/google/gson/JsonElement;
-	public abstract fun getExtras ()Lcom/google/gson/JsonObject;
+	public abstract fun getData ()Lcom/ably/chat/json/JsonObject;
+	public abstract fun getExtras ()Lcom/ably/chat/json/JsonObject;
 	public abstract fun getUpdatedAt ()J
 }
 
@@ -509,7 +509,7 @@ public abstract interface class com/ably/chat/RoomReaction {
 	public abstract fun getClientId ()Ljava/lang/String;
 	public abstract fun getCreatedAt ()J
 	public abstract fun getHeaders ()Ljava/util/Map;
-	public abstract fun getMetadata ()Lcom/google/gson/JsonObject;
+	public abstract fun getMetadata ()Lcom/ably/chat/json/JsonObject;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun isSelf ()Z
 }
@@ -529,12 +529,12 @@ public final class com/ably/chat/RoomReactionEventType : java/lang/Enum {
 
 public abstract interface class com/ably/chat/RoomReactions {
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
-	public abstract fun send (Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/RoomReactions$Listener;)Lcom/ably/chat/Subscription;
 }
 
 public final class com/ably/chat/RoomReactions$DefaultImpls {
-	public static synthetic fun send$default (Lcom/ably/chat/RoomReactions;Ljava/lang/String;Lcom/google/gson/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun send$default (Lcom/ably/chat/RoomReactions;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/RoomReactions$Listener {
@@ -645,5 +645,158 @@ public abstract interface annotation class com/ably/chat/annotations/ChatDsl : j
 }
 
 public abstract interface annotation class com/ably/chat/annotations/ExperimentalChatApi : java/lang/annotation/Annotation {
+}
+
+public final class com/ably/chat/json/JsonArray : com/ably/chat/json/JsonValue, java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun add (ILcom/ably/chat/json/JsonValue;)V
+	public synthetic fun add (ILjava/lang/Object;)V
+	public fun add (Lcom/ably/chat/json/JsonValue;)Z
+	public synthetic fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Lcom/ably/chat/json/JsonValue;)Z
+	public final fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public fun get (I)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun get (I)Ljava/lang/Object;
+	public fun getSize ()I
+	public fun hashCode ()I
+	public fun indexOf (Lcom/ably/chat/json/JsonValue;)I
+	public final fun indexOf (Ljava/lang/Object;)I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public fun lastIndexOf (Lcom/ably/chat/json/JsonValue;)I
+	public final fun lastIndexOf (Ljava/lang/Object;)I
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public fun remove (I)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun remove (I)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILcom/ably/chat/json/JsonValue;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun size ()I
+	public fun sort (Ljava/util/Comparator;)V
+	public fun subList (II)Ljava/util/List;
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ably/chat/json/JsonArrayBuilder {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun add (Ljava/lang/Object;)Lcom/ably/chat/json/JsonArrayBuilder;
+	public final fun addArray (Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonArrayBuilder;
+	public final fun addObject (Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonArrayBuilder;
+}
+
+public final class com/ably/chat/json/JsonBoolean : com/ably/chat/json/JsonValue {
+	public fun <init> (Z)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ably/chat/json/JsonBuilderKt {
+	public static final fun jsonArray (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonArray;
+	public static synthetic fun jsonArray$default (Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/ably/chat/json/JsonArray;
+	public static final fun jsonObject (Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonObject;
+	public static synthetic fun jsonObject$default (Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/ably/chat/json/JsonObject;
+}
+
+public final class com/ably/chat/json/JsonNull : com/ably/chat/json/JsonValue {
+	public static final field INSTANCE Lcom/ably/chat/json/JsonNull;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ably/chat/json/JsonNumber : com/ably/chat/json/JsonValue {
+	public fun <init> (Ljava/lang/Number;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/ably/chat/json/JsonObject : com/ably/chat/json/JsonValue, java/util/Map, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clear ()V
+	public synthetic fun compute (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun compute (Ljava/lang/String;Ljava/util/function/BiFunction;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun computeIfAbsent (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
+	public fun computeIfAbsent (Ljava/lang/String;Ljava/util/function/Function;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun computeIfPresent (Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun computeIfPresent (Ljava/lang/String;Ljava/util/function/BiFunction;)Lcom/ably/chat/json/JsonValue;
+	public final fun containsKey (Ljava/lang/Object;)Z
+	public fun containsKey (Ljava/lang/String;)Z
+	public fun containsValue (Lcom/ably/chat/json/JsonValue;)Z
+	public final fun containsValue (Ljava/lang/Object;)Z
+	public final fun entrySet ()Ljava/util/Set;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (Ljava/lang/Object;)Lcom/ably/chat/json/JsonValue;
+	public final synthetic fun get (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun get (Ljava/lang/String;)Lcom/ably/chat/json/JsonValue;
+	public fun getEntries ()Ljava/util/Set;
+	public fun getKeys ()Ljava/util/Set;
+	public fun getSize ()I
+	public fun getValues ()Ljava/util/Collection;
+	public fun hashCode ()I
+	public fun isEmpty ()Z
+	public final fun keySet ()Ljava/util/Set;
+	public synthetic fun merge (Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+	public fun merge (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;Ljava/util/function/BiFunction;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun put (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;)Lcom/ably/chat/json/JsonValue;
+	public fun putAll (Ljava/util/Map;)V
+	public synthetic fun putIfAbsent (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun putIfAbsent (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;)Lcom/ably/chat/json/JsonValue;
+	public fun remove (Ljava/lang/Object;)Lcom/ably/chat/json/JsonValue;
+	public synthetic fun remove (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public synthetic fun replace (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Z
+	public fun replace (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;)Lcom/ably/chat/json/JsonValue;
+	public fun replace (Ljava/lang/String;Lcom/ably/chat/json/JsonValue;Lcom/ably/chat/json/JsonValue;)Z
+	public fun replaceAll (Ljava/util/function/BiFunction;)V
+	public final fun size ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun values ()Ljava/util/Collection;
+}
+
+public final class com/ably/chat/json/JsonObjectBuilder {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun put (Ljava/lang/String;Ljava/lang/Object;)Lcom/ably/chat/json/JsonObjectBuilder;
+	public final fun putArray (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonObjectBuilder;
+	public final fun putObject (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/ably/chat/json/JsonObjectBuilder;
+}
+
+public final class com/ably/chat/json/JsonString : com/ably/chat/json/JsonValue {
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/ably/chat/json/JsonValue {
+	public static final field Companion Lcom/ably/chat/json/JsonValue$Companion;
+}
+
+public final class com/ably/chat/json/JsonValue$Companion {
 }
 

--- a/chat/src/commonMain/kotlin/com/ably/chat/GsonUtils.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/GsonUtils.kt
@@ -1,0 +1,57 @@
+package com.ably.chat
+
+import com.ably.chat.json.JsonArray
+import com.ably.chat.json.JsonBoolean
+import com.ably.chat.json.JsonNull
+import com.ably.chat.json.JsonNumber
+import com.ably.chat.json.JsonObject
+import com.ably.chat.json.JsonString
+import com.ably.chat.json.JsonValue
+import com.ably.chat.json.jsonArray
+import com.ably.chat.json.jsonObject
+import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
+import kotlin.collections.component1
+import kotlin.collections.component2
+
+internal fun JsonValue.toGson(): JsonElement = when (this) {
+    is JsonNull -> com.google.gson.JsonNull.INSTANCE
+    is JsonString -> JsonPrimitive(this.value)
+    is JsonNumber -> JsonPrimitive(this.value)
+    is JsonBoolean -> JsonPrimitive(this.value)
+    is JsonArray -> {
+        val jsonArray = com.google.gson.JsonArray()
+        forEach { jsonArray.add(it.toGson()) }
+        jsonArray
+    }
+    is JsonObject -> {
+        val jsonObject = com.google.gson.JsonObject()
+        forEach { (key, value) -> jsonObject.add(key, value.toGson()) }
+        jsonObject
+    }
+}
+
+private fun JsonElement.toJsonValue(): JsonValue = when {
+    isJsonNull -> JsonNull
+    isJsonObject -> jsonObject {
+        asJsonObject.entrySet().forEach { (key, value) -> put(key, value.toJsonValue()) }
+    }
+
+    isJsonArray -> jsonArray {
+        asJsonArray.forEach { add(it.toJsonValue()) }
+    }
+
+    isJsonPrimitive -> when {
+        asJsonPrimitive.isBoolean -> JsonBoolean(asBoolean)
+        asJsonPrimitive.isNumber -> JsonNumber(asNumber)
+        asJsonPrimitive.isString -> JsonString(asString)
+        else -> throw ClassCastException("Unknown type of json primitive: ${this.javaClass}")
+    }
+
+    else -> throw ClassCastException("Unknown type of json element: ${this.javaClass}")
+}
+
+internal fun Any?.tryAsJsonValue(): JsonValue? = when (this) {
+    is JsonElement -> toJsonValue()
+    else -> null
+}

--- a/chat/src/commonMain/kotlin/com/ably/chat/Message.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Message.kt
@@ -1,6 +1,6 @@
 package com.ably.chat
 
-import com.google.gson.JsonObject
+import com.ably.chat.json.JsonObject
 import io.ably.lib.types.Message.Operation
 import io.ably.lib.types.MessageAction
 import io.ably.lib.types.Summary
@@ -193,17 +193,19 @@ internal fun buildMessageOperation(jsonObject: JsonObject?): Operation? {
         return null
     }
     val operation = Operation()
-    if (jsonObject.has(MessageOperationProperty.ClientId)) {
-        operation.clientId = jsonObject.get(MessageOperationProperty.ClientId).asString
+
+    jsonObject[MessageOperationProperty.ClientId]?.tryAsString()?.let { clientId ->
+        operation.clientId = clientId
     }
-    if (jsonObject.has(MessageOperationProperty.Description)) {
-        operation.description = jsonObject.get(MessageOperationProperty.Description).asString
+
+    jsonObject[MessageOperationProperty.Description]?.tryAsString()?.let { description ->
+        operation.description = description
     }
-    if (jsonObject.has(MessageOperationProperty.Metadata)) {
-        val metadataObject = jsonObject.getAsJsonObject(MessageOperationProperty.Metadata)
+
+    jsonObject[MessageOperationProperty.Metadata]?.tryAsJsonObject()?.let { metadataObject ->
         operation.metadata = mutableMapOf()
-        for ((key, value) in metadataObject.entrySet()) {
-            operation.metadata[key] = value.asString
+        for ((key, value) in metadataObject.entries) {
+            operation.metadata[key] = value.tryAsString()
         }
     }
     return operation
@@ -220,14 +222,14 @@ internal fun buildMessageOperation(clientId: String, description: String?, metad
 internal fun buildMessageReactions(jsonObject: JsonObject?): MessageReactions {
     if (jsonObject == null) return DefaultMessageReactions()
 
-    val uniqueJson = jsonObject.getAsJsonObject(MessageReactionsProperty.Unique)
-    val distinctJson = jsonObject.getAsJsonObject(MessageReactionsProperty.Distinct)
-    val multipleJson = jsonObject.getAsJsonObject(MessageReactionsProperty.Multiple)
+    val uniqueJson = jsonObject[MessageReactionsProperty.Unique]
+    val distinctJson = jsonObject[MessageReactionsProperty.Distinct]
+    val multipleJson = jsonObject[MessageReactionsProperty.Multiple]
 
     return DefaultMessageReactions(
-        unique = uniqueJson?.let { Summary.asSummaryUniqueV1(it) } ?: mapOf(),
-        distinct = distinctJson?.let { Summary.asSummaryDistinctV1(it) } ?: mapOf(),
-        multiple = multipleJson?.let { Summary.asSummaryMultipleV1(it) } ?: mapOf(),
+        unique = uniqueJson?.let { Summary.asSummaryUniqueV1(it.toGson().asJsonObject) } ?: mapOf(),
+        distinct = distinctJson?.let { Summary.asSummaryDistinctV1(it.toGson().asJsonObject) } ?: mapOf(),
+        multiple = multipleJson?.let { Summary.asSummaryMultipleV1(it.toGson().asJsonObject) } ?: mapOf(),
     )
 }
 

--- a/chat/src/commonMain/kotlin/com/ably/chat/MessagesReactions.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/MessagesReactions.kt
@@ -1,6 +1,5 @@
 package com.ably.chat
 
-import com.google.gson.JsonObject
 import io.ably.lib.realtime.Channel
 import io.ably.lib.realtime.RealtimeAnnotations
 import io.ably.lib.types.Annotation
@@ -476,9 +475,9 @@ internal class DefaultMessagesReactions(
             return
         }
 
-        val unique = Summary.asSummaryUniqueV1(message.summary.get(MessageReactionType.Unique.type) ?: JsonObject())
-        val distinct = Summary.asSummaryDistinctV1(message.summary.get(MessageReactionType.Distinct.type) ?: JsonObject())
-        val multiple = Summary.asSummaryMultipleV1(message.summary.get(MessageReactionType.Multiple.type) ?: JsonObject())
+        val unique = message.summary.get(MessageReactionType.Unique.type)?.let { Summary.asSummaryUniqueV1(it) } ?: mapOf()
+        val distinct = message.summary.get(MessageReactionType.Distinct.type)?.let { Summary.asSummaryDistinctV1(it) } ?: mapOf()
+        val multiple = message.summary.get(MessageReactionType.Multiple.type)?.let { Summary.asSummaryMultipleV1(it) } ?: mapOf()
 
         summaryEventBus.tryEmit(
             DefaultMessageReactionSummaryEvent(

--- a/chat/src/commonMain/kotlin/com/ably/chat/Metadata.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Metadata.kt
@@ -1,6 +1,6 @@
 package com.ably.chat
 
-import com.google.gson.JsonObject
+import com.ably.chat.json.JsonObject
 
 /**
  * Metadata is a map of extra information that can be attached to chat

--- a/chat/src/commonMain/kotlin/com/ably/chat/Occupancy.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Occupancy.kt
@@ -2,8 +2,6 @@ package com.ably.chat
 
 import com.ably.annotations.InternalAPI
 import com.ably.pubsub.RealtimeChannel
-import com.google.gson.JsonObject
-import com.google.gson.JsonPrimitive
 import io.ably.lib.realtime.Channel
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
@@ -205,7 +203,7 @@ internal class DefaultOccupancy(
      */
     @Suppress("ReturnCount")
     private fun internalChannelListener(message: PubSubMessage) {
-        val data = message.data as? JsonObject
+        val data = message.data?.tryAsJsonValue()
 
         if (data == null) {
             logger.error(
@@ -218,7 +216,7 @@ internal class DefaultOccupancy(
             return
         }
 
-        val metrics = data.get("metrics") as? JsonObject
+        val metrics = data.tryAsJsonObject()?.get("metrics")
 
         if (metrics == null) {
             logger.error(
@@ -231,7 +229,7 @@ internal class DefaultOccupancy(
             return
         }
 
-        val connections = metrics.get("connections") as? JsonPrimitive
+        val connections = metrics.tryAsJsonObject()?.get("connections")?.tryAsInt()
 
         if (connections == null) {
             logger.error(
@@ -244,7 +242,7 @@ internal class DefaultOccupancy(
             return
         }
 
-        val presenceMembers = metrics.get("presenceMembers") as? JsonPrimitive
+        val presenceMembers = metrics.tryAsJsonObject()?.get("presenceMembers")?.tryAsInt()
 
         if (presenceMembers == null) {
             logger.error(
@@ -258,8 +256,8 @@ internal class DefaultOccupancy(
         }
 
         val occupancyData = DefaultOccupancyData(
-            connections = connections.asInt,
-            presenceMembers = presenceMembers.asInt,
+            connections = connections,
+            presenceMembers = presenceMembers,
         )
 
         latestOccupancyData = occupancyData

--- a/chat/src/commonMain/kotlin/com/ably/chat/Presence.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Presence.kt
@@ -1,15 +1,14 @@
 package com.ably.chat
 
 import com.ably.annotations.InternalAPI
+import com.ably.chat.json.JsonObject
 import com.ably.pubsub.RealtimeChannel
 import com.ably.pubsub.RealtimePresence
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
 import io.ably.lib.realtime.Channel
 import kotlinx.coroutines.flow.Flow
 import io.ably.lib.realtime.Presence.PresenceListener as PubSubPresenceListener
 
-public typealias PresenceData = JsonElement
+public typealias PresenceData = JsonObject
 
 /**
  * This interface is used to interact with presence in a chat room: subscribing to presence events,
@@ -156,7 +155,7 @@ internal class DefaultPresence(
             DefaultPresenceMember(
                 clientId = user.clientId,
                 connectionId = user.connectionId,
-                data = user.data as? JsonElement,
+                data = user.data.tryAsJsonValue()?.tryAsJsonObject(),
                 updatedAt = user.timestamp,
             )
         }
@@ -191,7 +190,7 @@ internal class DefaultPresence(
                 clientId = it.clientId,
                 connectionId = it.connectionId,
                 updatedAt = it.timestamp,
-                data = it.data as? JsonElement,
+                data = it.data.tryAsJsonValue()?.tryAsJsonObject(),
             )
             val presenceEvent = DefaultPresenceEvent(
                 type = PresenceEventType.fromPresenceAction(it.action),

--- a/chat/src/commonMain/kotlin/com/ably/chat/Utils.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/Utils.kt
@@ -1,10 +1,9 @@
 package com.ably.chat
 
+import com.ably.chat.json.JsonObject
+import com.ably.chat.json.jsonObject
 import com.ably.pubsub.RealtimeChannel
 import com.ably.pubsub.RealtimePresence
-import com.google.gson.JsonElement
-import com.google.gson.JsonNull
-import com.google.gson.JsonObject
 import io.ably.lib.realtime.CompletionListener
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.ChannelOptions
@@ -72,11 +71,11 @@ internal suspend fun RealtimePresence.getCoroutine(
     get(waitForSync = waitForSync, clientId = clientId, connectionId = connectionId)
 }
 
-internal suspend fun RealtimePresence.enterClientCoroutine(clientId: String, data: JsonElement? = JsonNull.INSTANCE) =
+internal suspend fun RealtimePresence.enterClientCoroutine(clientId: String, data: JsonObject?) =
     suspendCancellableCoroutine { continuation ->
         enterClient(
             clientId,
-            data,
+            data?.toGson(),
             object : CompletionListener {
                 override fun onSuccess() {
                     continuation.resume(Unit)
@@ -89,11 +88,11 @@ internal suspend fun RealtimePresence.enterClientCoroutine(clientId: String, dat
         )
     }
 
-internal suspend fun RealtimePresence.updateClientCoroutine(clientId: String, data: JsonElement? = JsonNull.INSTANCE) =
+internal suspend fun RealtimePresence.updateClientCoroutine(clientId: String, data: JsonObject?) =
     suspendCancellableCoroutine { continuation ->
         updateClient(
             clientId,
-            data,
+            data?.toGson(),
             object : CompletionListener {
                 override fun onSuccess() {
                     continuation.resume(Unit)
@@ -106,11 +105,11 @@ internal suspend fun RealtimePresence.updateClientCoroutine(clientId: String, da
         )
     }
 
-internal suspend fun RealtimePresence.leaveClientCoroutine(clientId: String, data: JsonElement? = JsonNull.INSTANCE) =
+internal suspend fun RealtimePresence.leaveClientCoroutine(clientId: String, data: JsonObject?) =
     suspendCancellableCoroutine { continuation ->
         leaveClient(
             clientId,
-            data,
+            data?.toGson(),
             object : CompletionListener {
                 override fun onSuccess() {
                     continuation.resume(Unit)
@@ -140,7 +139,7 @@ internal fun ChatChannelOptions(init: (ChannelOptions.() -> Unit)? = null): Chan
  */
 internal fun Message.asEphemeralMessage(): Message {
     return apply {
-        extras = extras ?: MessageExtras(JsonObject())
+        extras = extras ?: MessageExtras(jsonObject {}.toGson().asJsonObject)
         extras.asJsonObject().addProperty("ephemeral", true)
     }
 }

--- a/chat/src/commonMain/kotlin/com/ably/chat/json/Json.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/json/Json.kt
@@ -1,0 +1,76 @@
+package com.ably.chat.json
+
+/**
+ * JSON representation
+ */
+public sealed interface JsonValue {
+
+    public companion object {
+
+        /**
+         * Create JsonValue from common Kotlin types
+         */
+        internal fun of(value: Any?): JsonValue = when (value) {
+            null -> JsonNull
+            is JsonValue -> value
+            is Boolean -> JsonBoolean(value)
+            is String -> JsonString(value)
+            is Number -> JsonNumber(value)
+            is List<*> -> JsonArray(value.map { of(it) })
+            is Map<*, *> -> JsonObject(value.mapKeys { it.key.toString() }.mapValues { of(it.value) })
+            else -> JsonString(value.toString())
+        }
+    }
+}
+
+/**
+ * Represents a JSON null value
+ */
+public data object JsonNull : JsonValue {
+    override fun toString(): String = "null"
+}
+
+/**
+ * Represents a JSON boolean value
+ */
+public class JsonBoolean(public val value: Boolean) : JsonValue {
+    override fun toString(): String = value.toString()
+    override fun equals(other: Any?): Boolean = other is JsonBoolean && value == other.value
+    override fun hashCode(): Int = value.hashCode()
+}
+
+/**
+ * Represents a JSON number value
+ */
+public class JsonNumber(public val value: Number) : JsonValue {
+    override fun toString(): String = value.toString()
+    override fun equals(other: Any?): Boolean = other is JsonNumber && value == other.value
+    override fun hashCode(): Int = value.hashCode()
+}
+
+/**
+ * Represents a JSON string value
+ */
+public class JsonString(public val value: String) : JsonValue {
+    override fun toString(): String = "\"$value\""
+    override fun equals(other: Any?): Boolean = other is JsonString && value == other.value
+    override fun hashCode(): Int = value.hashCode()
+}
+
+/**
+ * Represents a JSON array
+ */
+public class JsonArray(private val values: List<JsonValue> = listOf()) : JsonValue, List<JsonValue> by values {
+    override fun toString(): String = "[${values.joinToString(", ")}]"
+    override fun equals(other: Any?): Boolean = other is JsonArray && values == other.values
+    override fun hashCode(): Int = values.hashCode()
+}
+
+/**
+ * Represents a JSON object
+ */
+public class JsonObject(private val fields: Map<String, JsonValue> = mapOf()) : JsonValue, Map<String, JsonValue> by fields {
+    override fun toString(): String = "{${fields.entries.joinToString(", ") { "\"${it.key}\": ${it.value}" }}}"
+    override fun equals(other: Any?): Boolean = other is JsonObject && fields == other.fields
+    override fun hashCode(): Int = fields.hashCode()
+}

--- a/chat/src/commonMain/kotlin/com/ably/chat/json/JsonBuilder.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/json/JsonBuilder.kt
@@ -1,0 +1,93 @@
+package com.ably.chat.json
+
+import com.ably.chat.annotations.ChatDsl
+
+/**
+ * Builder class for constructing JSON objects in a structured and type-safe way.
+ *
+ * This class provides methods to add key-value pairs to a JSON object, supporting various types
+ * of values such as primitives, nulls, arrays, and nested objects.
+ *
+ * Methods in this class follow a builder pattern and return the instance of the builder itself
+ * to allow for method chaining. When the configuration is complete, the `build` method can be
+ * called to create an immutable [JsonObject].
+ *
+ * Usage of this class is typically done within the context of a DSL, enabled by the `@ChatDsl` annotation.
+ */
+public class JsonObjectBuilder(initialFields: Map<String, JsonValue> = emptyMap()) {
+    private val fields = initialFields.toMutableMap()
+
+    public fun put(key: String, value: Any?): JsonObjectBuilder {
+        fields[key] = JsonValue.of(value)
+        return this
+    }
+
+    public fun putArray(key: String, builder: JsonArrayBuilder.() -> Unit): JsonObjectBuilder {
+        fields[key] = jsonArray(builder = builder)
+        return this
+    }
+
+    public fun putObject(key: String, builder: JsonObjectBuilder.() -> Unit): JsonObjectBuilder {
+        fields[key] = jsonObject(builder = builder)
+        return this
+    }
+
+    internal fun build(): JsonObject = JsonObject(fields.toMap())
+}
+
+/**
+ * Builder class for creating JSON arrays in a structured and type-safe manner.
+ *
+ * Provides methods to add various types of elements, such as primitive values, nulls,
+ * other JSON arrays, and JSON objects, to a JSON array being constructed.
+ */
+public class JsonArrayBuilder(initialValues: List<JsonValue> = emptyList()) {
+    private val values = initialValues.toMutableList()
+
+    public fun add(value: Any?): JsonArrayBuilder {
+        values.add(JsonValue.of(value))
+        return this
+    }
+
+    public fun addArray(builder: JsonArrayBuilder.() -> Unit): JsonArrayBuilder {
+        values.add(jsonArray(builder = builder))
+        return this
+    }
+
+    public fun addObject(builder: JsonObjectBuilder.() -> Unit): JsonArrayBuilder {
+        values.add(jsonObject(builder = builder))
+        return this
+    }
+
+    internal fun build(): JsonArray = JsonArray(values.toList())
+}
+
+/**
+ * Creates a new [JsonObject] using the provided initial fields and a lambda for adding or modifying fields.
+ * This function is part of a DSL for building JSON objects in a structured and type-safe way.
+ *
+ * @param initialFields The initial fields to populate the JSON object with. Defaults to an empty map.
+ * @param builder A lambda that defines additional fields or modifications to construct the JSON object.
+ * @return A new [JsonObject] containing the specified fields and modifications.
+ */
+@ChatDsl
+public fun jsonObject(initialFields: Map<String, JsonValue> = emptyMap(), builder: JsonObjectBuilder.() -> Unit): JsonObject =
+    JsonObjectBuilder(initialFields).apply(builder).build()
+
+/**
+ * Creates a [JsonArray] using the given initial values and builder lambda.
+ *
+ * This function constructs a `JsonArray` by initializing it with the provided list of
+ * `JsonValue` objects (if any) and then applying the given DSL builder to further configure
+ * its contents.
+ *
+ * The builder is executed within the context of a [JsonArrayBuilder], which provides methods
+ * to add various types of elements to the array.
+ *
+ * @param initialValues an optional list of initial [JsonValue] objects to populate the array. Defaults to an empty list.
+ * @param builder a DSL builder lambda used to configure the contents of the JSON array.
+ * @return a [JsonArray] instance containing the elements defined by the initial values and the builder.
+ */
+@ChatDsl
+public fun jsonArray(initialValues: List<JsonValue> = emptyList(), builder: JsonArrayBuilder.() -> Unit): JsonArray =
+    JsonArrayBuilder(initialValues).apply(builder).build()

--- a/chat/src/commonTest/kotlin/com/ably/chat/ChatApiTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/ChatApiTest.kt
@@ -1,7 +1,7 @@
 package com.ably.chat
 
+import com.ably.chat.json.jsonObject
 import com.ably.pubsub.RealtimeClient
-import com.google.gson.JsonObject
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.MessageAction
 import io.mockk.mockk
@@ -26,16 +26,17 @@ class ChatApiTest {
         mockMessagesApiResponse(
             realtime,
             listOf(
-                JsonObject().apply {
-                    addProperty("foo", "bar")
-                    add(MessageProperty.Metadata, JsonObject())
-                    addProperty(MessageProperty.Serial, "timeserial")
-                    addProperty(MessageProperty.ClientId, "clientId")
-                    addProperty(MessageProperty.Text, "hello")
-                    addProperty(MessageProperty.CreatedAt, 1_000_000)
-                    addProperty(MessageProperty.Action, "message.create")
-                    addProperty(MessageProperty.Version, "timeserial")
-                    addProperty(MessageProperty.Timestamp, 1_000_000)
+                jsonObject {
+                    put("foo", "bar")
+                    putObject(MessageProperty.Metadata) {
+                    }
+                    put(MessageProperty.Serial, "timeserial")
+                    put(MessageProperty.ClientId, "clientId")
+                    put(MessageProperty.Text, "hello")
+                    put(MessageProperty.CreatedAt, 1_000_000)
+                    put(MessageProperty.Action, "message.create")
+                    put(MessageProperty.Version, "timeserial")
+                    put(MessageProperty.Timestamp, 1_000_000)
                 },
             ),
         )
@@ -68,9 +69,9 @@ class ChatApiTest {
         mockMessagesApiResponse(
             realtime,
             listOf(
-                JsonObject().apply {
-                    addProperty("foo", "bar")
-                    addProperty(MessageProperty.Action, "message.create")
+                jsonObject {
+                    put("foo", "bar")
+                    put(MessageProperty.Action, "message.create")
                 },
             ),
         )
@@ -90,14 +91,14 @@ class ChatApiTest {
         mockMessagesApiResponse(
             realtime,
             listOf(
-                JsonObject().apply {
-                    add(MessageProperty.Metadata, JsonObject())
-                    addProperty(MessageProperty.Serial, "timeserial")
-                    addProperty(MessageProperty.ClientId, "clientId")
-                    addProperty(MessageProperty.CreatedAt, 1_000_000)
-                    addProperty(MessageProperty.Action, "message.delete")
-                    addProperty(MessageProperty.Version, "timeserial")
-                    addProperty(MessageProperty.Timestamp, 1_000_000)
+                jsonObject {
+                    putObject(MessageProperty.Metadata) {}
+                    put(MessageProperty.Serial, "timeserial")
+                    put(MessageProperty.ClientId, "clientId")
+                    put(MessageProperty.CreatedAt, 1_000_000)
+                    put(MessageProperty.Action, "message.delete")
+                    put(MessageProperty.Version, "timeserial")
+                    put(MessageProperty.Timestamp, 1_000_000)
                 },
             ),
         )
@@ -127,10 +128,10 @@ class ChatApiTest {
     fun `sendMessage should ignore unknown fields for Chat Backend`() = runTest {
         mockSendMessageApiResponse(
             realtime,
-            JsonObject().apply {
-                addProperty("foo", "bar")
-                addProperty(MessageProperty.Serial, "timeserial")
-                addProperty(MessageProperty.CreatedAt, 1_000_000)
+            jsonObject {
+                put("foo", "bar")
+                put(MessageProperty.Serial, "timeserial")
+                put(MessageProperty.CreatedAt, 1_000_000)
             },
         )
 
@@ -159,9 +160,9 @@ class ChatApiTest {
     fun `sendMessage should throw exception if 'serial' field is not presented`() = runTest {
         mockSendMessageApiResponse(
             realtime,
-            JsonObject().apply {
-                addProperty("foo", "bar")
-                addProperty(MessageProperty.CreatedAt, 1_000_000)
+            jsonObject {
+                put("foo", "bar")
+                put(MessageProperty.CreatedAt, 1_000_000)
             },
         )
 
@@ -177,8 +178,8 @@ class ChatApiTest {
     fun `getOccupancy should throw exception if 'connections' field is not presented`() = runTest {
         mockOccupancyApiResponse(
             realtime,
-            JsonObject().apply {
-                addProperty("presenceMembers", 1_000)
+            jsonObject {
+                put("presenceMembers", 1_000)
             },
         )
 

--- a/chat/src/commonTest/kotlin/com/ably/chat/MessageTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/MessageTest.kt
@@ -1,6 +1,6 @@
 package com.ably.chat
 
-import com.google.gson.JsonObject
+import com.ably.chat.json.jsonObject
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.MessageAction
 import io.ably.lib.types.SummaryClientIdCounts
@@ -187,7 +187,7 @@ private fun createMessage(
     version = version,
     clientId = "client1",
     createdAt = System.currentTimeMillis(),
-    metadata = JsonObject(),
+    metadata = jsonObject {},
     headers = mapOf(),
     action = action,
     timestamp = System.currentTimeMillis(),

--- a/chat/src/commonTest/kotlin/com/ably/chat/MessagesReactionsTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/MessagesReactionsTest.kt
@@ -1,9 +1,8 @@
 package com.ably.chat
 
+import com.ably.chat.json.jsonObject
 import com.ably.chat.room.createMockChatApi
 import com.ably.chat.room.createMockRealtimeClient
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
 import io.ably.lib.realtime.RealtimeAnnotations
 import io.ably.lib.realtime.buildRealtimeChannel
 import io.ably.lib.types.AblyException
@@ -78,20 +77,14 @@ class MessagesReactionsTest {
                 createdAt = 1000L
                 summary = Summary(
                     mapOf(
-                        "reaction:distinct.v1" to JsonObject().apply {
-                            add(
-                                "heart",
-                                JsonObject().apply {
-                                    addProperty("total", 1)
-                                    add(
-                                        "clientIds",
-                                        JsonArray().apply {
-                                            add("clientId")
-                                        },
-                                    )
-                                },
-                            )
-                        },
+                        "reaction:distinct.v1" to jsonObject {
+                            putObject("heart") {
+                                put("total", 1)
+                                putArray("clientIds") {
+                                    add("clientId")
+                                }
+                            }
+                        }.toGson().asJsonObject,
                     ),
                 )
                 action = MessageAction.MESSAGE_SUMMARY

--- a/chat/src/commonTest/kotlin/com/ably/chat/MessagesTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/MessagesTest.kt
@@ -2,11 +2,11 @@ package com.ably.chat
 
 import app.cash.turbine.test
 import com.ably.annotations.InternalAPI
+import com.ably.chat.json.jsonObject
 import com.ably.chat.room.createMockChatApi
 import com.ably.chat.room.createMockRealtimeChannel
 import com.ably.chat.room.createMockRealtimeClient
 import com.ably.chat.room.createTestRoom
-import com.google.gson.JsonObject
 import io.ably.lib.realtime.ChannelState
 import io.ably.lib.realtime.ChannelStateListener
 import io.ably.lib.realtime.buildChannelStateChange
@@ -53,9 +53,9 @@ class MessagesTest {
     fun `should be able to send message and get it back from response`() = runTest {
         mockSendMessageApiResponse(
             realtimeClient,
-            JsonObject().apply {
-                addProperty(MessageProperty.Serial, "abcdefghij@1672531200000-123")
-                addProperty(MessageProperty.CreatedAt, 1_000_000)
+            jsonObject {
+                put(MessageProperty.Serial, "abcdefghij@1672531200000-123")
+                put(MessageProperty.CreatedAt, 1_000_000)
             },
             roomName = "room1",
         )
@@ -63,7 +63,7 @@ class MessagesTest {
         val sentMessage = messages.send(
             text = "lala",
             headers = mapOf("foo" to "bar"),
-            metadata = JsonObject().apply { addProperty("meta", "data") },
+            metadata = jsonObject { put("meta", "data") },
         )
 
         assertEquals(
@@ -72,7 +72,7 @@ class MessagesTest {
                 clientId = "clientId",
                 text = "lala",
                 createdAt = 1_000_000,
-                metadata = JsonObject().apply { addProperty("meta", "data") },
+                metadata = jsonObject { put("meta", "data") },
                 headers = mapOf("foo" to "bar"),
                 action = MessageAction.MESSAGE_CREATE,
                 version = "abcdefghij@1672531200000-123",
@@ -101,23 +101,20 @@ class MessagesTest {
 
         pubSubMessageListenerSlot.captured.onMessage(
             PubSubMessage().apply {
-                data = JsonObject().apply {
-                    addProperty("text", "some text")
-                    add("metadata", JsonObject())
-                }
+                data = jsonObject {
+                    put("text", "some text")
+                    putObject("metadata") {}
+                }.toGson()
                 serial = "abcdefghij@1672531200000-123"
                 clientId = "clientId"
                 timestamp = 1000L
                 createdAt = 1000L
                 extras = MessageExtras(
-                    JsonObject().apply {
-                        add(
-                            "headers",
-                            JsonObject().apply {
-                                addProperty("foo", "bar")
-                            },
-                        )
-                    },
+                    jsonObject {
+                        putObject("headers") {
+                            put("foo", "bar")
+                        }
+                    }.toGson().asJsonObject,
                 )
                 action = MessageAction.MESSAGE_CREATE
                 version = "abcdefghij@1672531200000-123"
@@ -162,22 +159,19 @@ class MessagesTest {
 
         pubSubMessageListenerSlot.captured.onMessage(
             PubSubMessage().apply {
-                data = JsonObject().apply {
-                    add("metadata", JsonObject())
-                }
+                data = jsonObject {
+                    putObject("metadata") {}
+                }.toGson()
                 serial = "abcdefghij@1672531200000-123"
                 clientId = "clientId"
                 timestamp = 1000L
                 createdAt = 1000L
                 extras = MessageExtras(
-                    JsonObject().apply {
-                        add(
-                            "headers",
-                            JsonObject().apply {
-                                addProperty("foo", "bar")
-                            },
-                        )
-                    },
+                    jsonObject {
+                        putObject("headers") {
+                            put("foo", "bar")
+                        }
+                    }.toGson().asJsonObject,
                 )
                 action = MessageAction.MESSAGE_DELETE
                 version = "abcdefghij@1672531200000-123"
@@ -321,16 +315,16 @@ class MessagesTest {
 }
 
 private fun buildDummyPubSubMessage() = PubSubMessage().apply {
-    data = JsonObject().apply {
-        addProperty("text", "dummy text")
-        add("metadata", JsonObject())
-    }
+    data = jsonObject {
+        put("text", "dummy text")
+        putObject("metadata") {}
+    }.toGson()
     serial = "abcdefghij@1672531200000-123"
     clientId = "dummy"
     timestamp = 1000L
     createdAt = 1000L
     extras = MessageExtras(
-        JsonObject().apply {},
+        jsonObject {}.toGson().asJsonObject,
     )
     action = MessageAction.MESSAGE_CREATE
     version = "abcdefghij@1672531200000-123"

--- a/chat/src/commonTest/kotlin/com/ably/chat/PresenceTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/PresenceTest.kt
@@ -1,13 +1,12 @@
 package com.ably.chat
 
 import app.cash.turbine.test
+import com.ably.chat.json.jsonObject
 import com.ably.chat.room.DEFAULT_ROOM_ID
 import com.ably.chat.room.createMockRealtimeChannel
 import com.ably.chat.room.createMockRealtimeClient
 import com.ably.chat.room.createTestRoom
 import com.ably.pubsub.RealtimePresence
-import com.google.gson.JsonObject
-import com.google.gson.JsonPrimitive
 import io.ably.lib.realtime.Presence.PresenceListener
 import io.ably.lib.types.AblyException
 import io.ably.lib.types.PresenceMessage
@@ -98,7 +97,7 @@ class PresenceTest {
                 clientId = "client1"
                 connectionId = "bar"
                 timestamp = 100_000L
-                data = JsonObject()
+                data = jsonObject {}.toGson()
             },
         )
 
@@ -111,7 +110,7 @@ class PresenceTest {
                     clientId = "client1",
                     connectionId = "bar",
                     updatedAt = 100_000L,
-                    data = JsonObject(),
+                    data = jsonObject {},
                 ),
             ),
             presenceEvent,
@@ -139,7 +138,9 @@ class PresenceTest {
                 connectionId = "foo"
                 clientId = "client1"
                 timestamp = 100_000L
-                data = JsonPrimitive("user")
+                data = jsonObject {
+                    put("clientId", "user")
+                }.toGson()
             },
         )
 
@@ -152,7 +153,9 @@ class PresenceTest {
                     clientId = "client1",
                     connectionId = "foo",
                     updatedAt = 100_000L,
-                    data = JsonPrimitive("user"),
+                    data = jsonObject {
+                        put("clientId", "user")
+                    },
                 ),
             ),
             presenceEvent,

--- a/chat/src/commonTest/kotlin/com/ably/chat/RoomReactionsTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/RoomReactionsTest.kt
@@ -1,11 +1,11 @@
 package com.ably.chat
 
 import app.cash.turbine.test
+import com.ably.chat.json.jsonObject
 import com.ably.chat.room.createMockRealtimeChannel
 import com.ably.chat.room.createMockRealtimeClient
 import com.ably.chat.room.createTestRoom
 import com.ably.pubsub.RealtimeChannel
-import com.google.gson.JsonObject
 import io.ably.lib.realtime.CompletionListener
 import io.ably.lib.realtime.Connection
 import io.ably.lib.realtime.ConnectionState
@@ -61,21 +61,18 @@ class RoomReactionsTest {
 
         pubSubMessageListenerSlot.captured.onMessage(
             PubSubMessage().apply {
-                data = JsonObject().apply {
-                    addProperty("name", "like")
-                    add("metadata", JsonObject())
-                }
+                data = jsonObject {
+                    put("name", "like")
+                    putObject("metadata") {}
+                }.toGson()
                 clientId = "clientId"
                 timestamp = 1000L
                 extras = MessageExtras(
-                    JsonObject().apply {
-                        add(
-                            "headers",
-                            JsonObject().apply {
-                                addProperty("foo", "bar")
-                            },
-                        )
-                    },
+                    jsonObject {
+                        putObject("headers") {
+                            put("foo", "bar")
+                        }
+                    }.toGson().asJsonObject,
                 )
             },
         )

--- a/chat/src/commonTest/kotlin/com/ably/chat/TestUtils.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/TestUtils.kt
@@ -1,8 +1,8 @@
 package com.ably.chat
 
+import com.ably.chat.json.JsonValue
 import com.ably.http.HttpMethod
 import com.ably.pubsub.RealtimeClient
-import com.google.gson.JsonElement
 import io.ably.lib.types.AsyncHttpPaginatedResponse
 import io.mockk.every
 import io.mockk.mockk
@@ -21,15 +21,15 @@ import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
-fun buildAsyncHttpPaginatedResponse(items: List<JsonElement>): AsyncHttpPaginatedResponse {
+fun buildAsyncHttpPaginatedResponse(items: List<JsonValue>): AsyncHttpPaginatedResponse {
     val response = mockk<AsyncHttpPaginatedResponse>()
     every {
         response.items()
-    } returns items.toTypedArray()
+    } returns items.map { it.toGson() }.toTypedArray()
     return response
 }
 
-fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<JsonElement>, roomName: String = "roomName") {
+fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<JsonValue>, roomName: String = "roomName") {
     every {
         realtimeClientMock.requestAsync("/chat/v3/rooms/$roomName/messages", any(), HttpMethod.Get, any(), any(), any())
     } answers {
@@ -40,7 +40,7 @@ fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<J
     }
 }
 
-fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: JsonElement, roomName: String = "roomName") {
+fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: JsonValue, roomName: String = "roomName") {
     every {
         realtimeClientMock.requestAsync("/chat/v3/rooms/$roomName/messages", any(), HttpMethod.Post, any(), any(), any())
     } answers {
@@ -53,7 +53,7 @@ fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: Jso
     }
 }
 
-fun mockOccupancyApiResponse(realtimeClientMock: RealtimeClient, response: JsonElement, roomName: String = "roomName") {
+fun mockOccupancyApiResponse(realtimeClientMock: RealtimeClient, response: JsonValue, roomName: String = "roomName") {
     every {
         realtimeClientMock.requestAsync("/chat/v3/rooms/$roomName/occupancy", any(), HttpMethod.Get, any(), any(), any())
     } answers {

--- a/chat/src/commonTest/kotlin/com/ably/chat/integration/MessagesIntegrationTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/integration/MessagesIntegrationTest.kt
@@ -4,13 +4,12 @@ import com.ably.chat.BuildConfig
 import com.ably.chat.ChatMessageEvent
 import com.ably.chat.MainDispatcherRule
 import com.ably.chat.Message
-import com.ably.chat.MessageMetadata
 import com.ably.chat.PlatformSpecificAgent
 import com.ably.chat.RoomStatus
 import com.ably.chat.assertWaiter
 import com.ably.chat.copy
+import com.ably.chat.json.jsonObject
 import com.ably.chat.room.RoomOptionsWithAllFeatures
-import com.google.gson.JsonObject
 import io.ably.lib.realtime.channelOptions
 import io.ably.lib.types.MessageAction
 import java.util.UUID
@@ -65,8 +64,9 @@ class MessagesIntegrationTest {
         val messageEvent = CompletableDeferred<ChatMessageEvent>()
         room.messages.subscribe { messageEvent.complete(it) }
 
-        val metadata = MessageMetadata()
-        metadata.addProperty("foo", "bar")
+        val metadata = jsonObject {
+            put("foo", "bar")
+        }
         val headers = mapOf("headerKey" to "headerValue")
         val sentMessage = room.messages.send("hello", metadata, headers)
 
@@ -107,8 +107,9 @@ class MessagesIntegrationTest {
 
         room.attach()
 
-        val metadata = MessageMetadata()
-        metadata.addProperty("foo", "bar")
+        val metadata = jsonObject {
+            put("foo", "bar")
+        }
         val headers = mapOf("headerKey" to "headerValue")
         val sentMessage = room.messages.send("hello", metadata, headers)
 
@@ -160,14 +161,16 @@ class MessagesIntegrationTest {
         val receivedMsges = mutableListOf<Message>()
         room.messages.subscribe { receivedMsges.add(it.message) }
 
-        val metadata = MessageMetadata()
-        metadata.addProperty("foo", "bar")
+        val metadata = jsonObject {
+            put("foo", "bar")
+        }
         val sentMessage = room.messages.send("hello", metadata, mapOf("headerKey" to "headerValue"))
         assertWaiter { receivedMsges.size == 1 }
 
         val updatedText = "hello updated"
-        val updatedMetadata = MessageMetadata()
-        updatedMetadata.addProperty("foo", "baz")
+        val updatedMetadata = jsonObject {
+            put("foo", "baz")
+        }
         val headers = mapOf("headerKey" to "headerValue")
 
         val opDescription = "Updating message"
@@ -217,8 +220,9 @@ class MessagesIntegrationTest {
         val receivedMsges = mutableListOf<Message>()
         room.messages.subscribe { receivedMsges.add(it.message) }
 
-        val metadata = MessageMetadata()
-        metadata.addProperty("foo", "bar")
+        val metadata = jsonObject {
+            put("foo", "bar")
+        }
         val sentMessage = room.messages.send("hello", metadata, mapOf("headerKey" to "headerValue"))
         assertWaiter { receivedMsges.size == 1 }
 
@@ -239,7 +243,7 @@ class MessagesIntegrationTest {
         val receivedMsg2 = receivedMsges.last()
 
         assertEquals("", receivedMsg2.text)
-        assertEquals(JsonObject(), receivedMsg2.metadata)
+        assertEquals(jsonObject {}, receivedMsg2.metadata)
         assertEquals(mapOf<String, String>(), receivedMsg2.headers)
         assertEquals(deletedMessage.operation?.description, receivedMsg2.operation?.description)
         assertEquals(deletedMessage.operation?.metadata, receivedMsg2.operation?.metadata)

--- a/example/src/main/java/com/ably/chat/example/ui/PresencePopup.kt
+++ b/example/src/main/java/com/ably/chat/example/ui/PresencePopup.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.window.Popup
 import com.ably.chat.Room
 import com.ably.chat.annotations.ExperimentalChatApi
 import com.ably.chat.extensions.compose.collectAsPresenceMembers
-import com.google.gson.JsonObject
+import com.ably.chat.json.jsonObject
 import kotlinx.coroutines.launch
 
 @Suppress("LongMethod")
@@ -45,15 +45,15 @@ fun PresencePopup(room: Room, onDismiss: () -> Unit) {
                 Text("Chat Members", style = MaterialTheme.typography.headlineMedium)
                 Spacer(modifier = Modifier.height(8.dp))
                 members.forEach { member ->
-                    BasicText("${member.clientId} - (${(member.data as? JsonObject)?.get("status")?.asString})")
+                    BasicText("${member.clientId} - (${member.data?.get("status")})")
                     Spacer(modifier = Modifier.height(4.dp))
                 }
                 Spacer(modifier = Modifier.height(8.dp))
                 Button(onClick = {
                     coroutineScope.launch {
                         presence.enter(
-                            JsonObject().apply {
-                                addProperty("status", "online")
+                            jsonObject {
+                                put("status", "online")
                             },
                         )
                     }
@@ -63,8 +63,8 @@ fun PresencePopup(room: Room, onDismiss: () -> Unit) {
                 Button(onClick = {
                     coroutineScope.launch {
                         presence.enter(
-                            JsonObject().apply {
-                                addProperty("status", "away")
+                            jsonObject {
+                                put("status", "away")
                             },
                         )
                     }


### PR DESCRIPTION
Migrates from Gson to a custom `Json` implementation across `chat` module components for parsing and serialization. Updates APIs, internal structures, and tests to reflect the new `JsonObject` and `JsonValue` types. Adjusts method signatures and deprecates Gson-specific usages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduces a first-party JSON model and DSL (JsonValue/JsonObject/JsonArray + jsonObject/jsonArray builders).

- Refactor
  - Public APIs now use the new built-in JSON types across messages, presence, reactions and pagination (may require client updates).
  - PresenceData type updated to the new JsonObject (breaking change for Gson-dependent code).

- Chores
  - Example app and tests migrated to the new JSON builders and helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->