### PR TITLE
feat: make update and delete work without the full message payload

### DIFF
--- a/chat/api/android/chat.api
+++ b/chat/api/android/chat.api
@@ -228,20 +228,20 @@ public abstract interface class com/ably/chat/MessageVersion {
 }
 
 public abstract interface class com/ably/chat/Messages {
-	public abstract fun delete (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun delete (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun getReactions ()Lcom/ably/chat/MessagesReactions;
 	public abstract fun history (Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Messages$Listener;)Lcom/ably/chat/MessagesSubscription;
-	public abstract fun update (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun update (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/ably/chat/Messages$DefaultImpls {
-	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun history$default (Lcom/ably/chat/Messages;Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun update$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun update$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/Messages$Listener {
@@ -250,6 +250,10 @@ public abstract interface class com/ably/chat/Messages$Listener {
 
 public final class com/ably/chat/MessagesKt {
 	public static final fun asFlow (Lcom/ably/chat/Messages;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun delete (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun update (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun update$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/MessagesReactions {

--- a/chat/api/jvm/chat.api
+++ b/chat/api/jvm/chat.api
@@ -228,20 +228,20 @@ public abstract interface class com/ably/chat/MessageVersion {
 }
 
 public abstract interface class com/ably/chat/Messages {
-	public abstract fun delete (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun delete (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getChannel ()Lio/ably/lib/realtime/Channel;
 	public abstract fun getReactions ()Lcom/ably/chat/MessagesReactions;
 	public abstract fun history (Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun send (Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun subscribe (Lcom/ably/chat/Messages$Listener;)Lcom/ably/chat/MessagesSubscription;
-	public abstract fun update (Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun update (Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/ably/chat/Messages$DefaultImpls {
-	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun history$default (Lcom/ably/chat/Messages;Ljava/lang/Long;Ljava/lang/Long;ILcom/ably/chat/OrderBy;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun send$default (Lcom/ably/chat/Messages;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun update$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun update$default (Lcom/ably/chat/Messages;Ljava/lang/String;Ljava/lang/String;Lcom/ably/chat/json/JsonObject;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/Messages$Listener {
@@ -250,6 +250,10 @@ public abstract interface class com/ably/chat/Messages$Listener {
 
 public final class com/ably/chat/MessagesKt {
 	public static final fun asFlow (Lcom/ably/chat/Messages;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun delete (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun delete$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun update (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun update$default (Lcom/ably/chat/Messages;Lcom/ably/chat/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/ably/chat/MessagesReactions {

--- a/chat/src/commonTest/kotlin/com/ably/chat/TestUtils.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/TestUtils.kt
@@ -31,7 +31,7 @@ fun buildAsyncHttpPaginatedResponse(items: List<JsonValue>): AsyncHttpPaginatedR
 
 fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<JsonValue>, roomName: String = "roomName") {
     every {
-        realtimeClientMock.requestAsync("/chat/v4/rooms/$roomName/messages", any(), HttpMethod.Get, any(), any(), any())
+        realtimeClientMock.requestAsync("/chat/v4/rooms/${encodePath(roomName)}/messages", any(), HttpMethod.Get, any(), any(), any())
     } answers {
         val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
         callback.onResponse(
@@ -42,7 +42,57 @@ fun mockMessagesApiResponse(realtimeClientMock: RealtimeClient, response: List<J
 
 fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: JsonValue, roomName: String = "roomName") {
     every {
-        realtimeClientMock.requestAsync("/chat/v4/rooms/$roomName/messages", any(), HttpMethod.Post, any(), any(), any())
+        realtimeClientMock.requestAsync("/chat/v4/rooms/${encodePath(roomName)}/messages", any(), HttpMethod.Post, any(), any(), any())
+    } answers {
+        val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
+        callback.onResponse(
+            buildAsyncHttpPaginatedResponse(
+                listOf(response),
+            ),
+        )
+    }
+}
+
+fun mockUpdateMessageApiResponse(
+    realtimeClientMock: RealtimeClient,
+    response: JsonValue,
+    roomName: String = "roomName",
+    serial: String = "timeserial",
+) {
+    every {
+        realtimeClientMock.requestAsync(
+            "/chat/v4/rooms/${encodePath(roomName)}/messages/${encodePath(serial)}",
+            any(),
+            HttpMethod.Put,
+            any(),
+            any(),
+            any(),
+        )
+    } answers {
+        val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
+        callback.onResponse(
+            buildAsyncHttpPaginatedResponse(
+                listOf(response),
+            ),
+        )
+    }
+}
+
+fun mockDeleteMessageApiResponse(
+    realtimeClientMock: RealtimeClient,
+    response: JsonValue,
+    roomName: String = "roomName",
+    serial: String = "timeserial",
+) {
+    every {
+        realtimeClientMock.requestAsync(
+            "/chat/v4/rooms/${encodePath(roomName)}/messages/${encodePath(serial)}/delete",
+            any(),
+            HttpMethod.Post,
+            any(),
+            any(),
+            any(),
+        )
     } answers {
         val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
         callback.onResponse(
@@ -55,7 +105,7 @@ fun mockSendMessageApiResponse(realtimeClientMock: RealtimeClient, response: Jso
 
 fun mockOccupancyApiResponse(realtimeClientMock: RealtimeClient, response: JsonValue, roomName: String = "roomName") {
     every {
-        realtimeClientMock.requestAsync("/chat/v4/rooms/$roomName/occupancy", any(), HttpMethod.Get, any(), any(), any())
+        realtimeClientMock.requestAsync("/chat/v4/rooms/${encodePath(roomName)}/occupancy", any(), HttpMethod.Get, any(), any(), any())
     } answers {
         val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
         callback.onResponse(
@@ -96,7 +146,7 @@ fun Any.setPrivateField(name: String, value: Any?) {
     valueField.set(this, value)
 }
 
-fun <T>Any.getPrivateField(name: String): T {
+fun <T> Any.getPrivateField(name: String): T {
     val valueField = javaClass.findField(name)
     valueField.isAccessible = true
     @Suppress("UNCHECKED_CAST")
@@ -117,7 +167,7 @@ private fun Class<*>.findField(name: String): Field {
     return result.getOrNull() as Field
 }
 
-suspend fun <T>Any.invokePrivateSuspendMethod(methodName: String, vararg args: Any?) = suspendCancellableCoroutine<T> { cont ->
+suspend fun <T> Any.invokePrivateSuspendMethod(methodName: String, vararg args: Any?) = suspendCancellableCoroutine<T> { cont ->
     val suspendMethod = javaClass.declaredMethods.find { it.name == methodName }
     suspendMethod?.let {
         it.isAccessible = true

--- a/chat/src/commonTest/kotlin/com/ably/chat/integration/MessagesIntegrationTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/integration/MessagesIntegrationTest.kt
@@ -8,8 +8,10 @@ import com.ably.chat.PlatformSpecificAgent
 import com.ably.chat.RoomStatus
 import com.ably.chat.assertWaiter
 import com.ably.chat.copy
+import com.ably.chat.delete
 import com.ably.chat.json.jsonObject
 import com.ably.chat.room.RoomOptionsWithAllFeatures
+import com.ably.chat.update
 import io.ably.lib.realtime.channelOptions
 import io.ably.lib.types.MessageAction
 import java.util.UUID

--- a/example/src/main/java/com/ably/chat/example/MainActivity.kt
+++ b/example/src/main/java/com/ably/chat/example/MainActivity.kt
@@ -51,10 +51,12 @@ import com.ably.chat.RoomReaction
 import com.ably.chat.annotations.ExperimentalChatApi
 import com.ably.chat.asFlow
 import com.ably.chat.copy
+import com.ably.chat.delete
 import com.ably.chat.example.ui.PresencePopup
 import com.ably.chat.example.ui.theme.AblyChatExampleTheme
 import com.ably.chat.extensions.compose.collectAsCurrentlyTyping
 import com.ably.chat.extensions.compose.collectAsPagingMessagesState
+import com.ably.chat.update
 import io.ably.lib.realtime.AblyRealtime
 import io.ably.lib.types.ClientOptions
 import java.util.UUID


### PR DESCRIPTION
Make update and delete work without the full message payload

Implements (CHA-M9d), (CHA-M8e)

Also added missed url path encoding for `roomName`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Messages update/delete now accept message serial (ID) with expanded payload and operation metadata; convenience overloads still accept Message objects.

- **Refactor**
  - Chat API percent-encodes room and message path segments; endpoints and logs now use encoded serial/roomName.

- **Tests**
  - Added tests for path encoding and URL/request construction; added test helpers for update/delete responses.

- **Chores**
  - Example and integration code updated to import/use new update/delete entry points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->