### PR TITLE
fix: add missing reaction path encoding and tests

### DIFF
--- a/chat/src/commonMain/kotlin/com/ably/chat/ChatApi.kt
+++ b/chat/src/commonMain/kotlin/com/ably/chat/ChatApi.kt
@@ -158,7 +158,7 @@ internal class ChatApi(
 
     suspend fun sendMessageReaction(roomName: String, messageSerial: String, type: MessageReactionType, name: String, count: Int = 1) {
         this.makeAuthorizedRequest(
-            url = "/chat/$CHAT_API_PROTOCOL_VERSION/rooms/${encodePath(roomName)}/messages/$messageSerial/reactions",
+            url = "/chat/$CHAT_API_PROTOCOL_VERSION/rooms/${encodePath(roomName)}/messages/${encodePath(messageSerial)}/reactions",
             method = HttpMethod.Post,
             body = buildMessageReactionsBody(type, name, count),
         )
@@ -166,7 +166,7 @@ internal class ChatApi(
 
     suspend fun deleteMessageReaction(roomName: String, messageSerial: String, type: MessageReactionType, name: String? = null) {
         this.makeAuthorizedRequest(
-            url = "/chat/$CHAT_API_PROTOCOL_VERSION/rooms/${encodePath(roomName)}/messages/$messageSerial/reactions",
+            url = "/chat/$CHAT_API_PROTOCOL_VERSION/rooms/${encodePath(roomName)}/messages/${encodePath(messageSerial)}/reactions",
             method = HttpMethod.Delete,
             params = buildMessageReactionsApiParams(type, name),
         )

--- a/chat/src/commonTest/kotlin/com/ably/chat/ChatApiTest.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/ChatApiTest.kt
@@ -285,6 +285,24 @@ class ChatApiTest {
     }
 
     @Test
+    fun `message reactions should encode path segments with special characters`() = runTest {
+        val roomName = "name/with spaces, slashes and \""
+        val timeserial = "0@0:02"
+        mockMessageReactionApiResponse(realtime, roomName, timeserial)
+        chatApi.deleteMessageReaction(roomName, timeserial, MessageReactionType.Unique)
+        chatApi.sendMessageReaction(roomName, timeserial, MessageReactionType.Unique, "heart")
+        verify(exactly = 2) {
+            realtime.requestAsync(
+                "/chat/v4/rooms/name%2Fwith%20spaces%2C%20slashes%20and%20%22/messages/0%400%3A02/reactions",
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun `getOccupancy should encode path segments with special characters`() = runTest {
         val roomName = "name/with spaces, slashes and \""
         mockOccupancyApiResponse(realtime, jsonObject {}, roomName)

--- a/chat/src/commonTest/kotlin/com/ably/chat/TestUtils.kt
+++ b/chat/src/commonTest/kotlin/com/ably/chat/TestUtils.kt
@@ -103,6 +103,30 @@ fun mockDeleteMessageApiResponse(
     }
 }
 
+fun mockMessageReactionApiResponse(
+    realtimeClientMock: RealtimeClient,
+    roomName: String = "roomName",
+    serial: String = "timeserial",
+) {
+    every {
+        realtimeClientMock.requestAsync(
+            "/chat/v4/rooms/${encodePath(roomName)}/messages/${encodePath(serial)}/reactions",
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+    } answers {
+        val callback = secondArg<AsyncHttpPaginatedResponse.Callback>()
+        callback.onResponse(
+            buildAsyncHttpPaginatedResponse(
+                listOf(),
+            ),
+        )
+    }
+}
+
 fun mockOccupancyApiResponse(realtimeClientMock: RealtimeClient, response: JsonValue, roomName: String = "roomName") {
     every {
         realtimeClientMock.requestAsync("/chat/v4/rooms/${encodePath(roomName)}/occupancy", any(), HttpMethod.Get, any(), any(), any())


### PR DESCRIPTION
add missing reaction path encoding and tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of adding and removing message reactions when room names or message identifiers contain special characters (e.g., spaces, slashes, quotes) by ensuring proper URL encoding.
  * No changes to the public API.

* **Tests**
  * Added test coverage to validate correct handling of special characters in reaction endpoints, ensuring paths are properly encoded and requests use the expected methods and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->